### PR TITLE
feat: native transfers support for transfer parsing

### DIFF
--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -5,7 +5,6 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "dev": "nodemon index.js",
     "db:generate": "prisma generate",
     "db:push": "prisma db push --skip-generate",
     "db:pull": "prisma db pull"

--- a/packages/makeover/package.json
+++ b/packages/makeover/package.json
@@ -4,6 +4,7 @@
   "description": "",
   "main": "./dist/index.js",
   "types": "./dist/index.ts",
+  "type": "module",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "dev": "nodemon .",

--- a/packages/makeover/parsers/transfer.ts
+++ b/packages/makeover/parsers/transfer.ts
@@ -1,3 +1,4 @@
+import { LAMPORTS_PER_SOL } from "@solana/web3.js";
 import { EnrichedTransaction, Source } from "../../../../helius-sdk/dist";
 
 interface Transfer {
@@ -11,12 +12,22 @@ interface Transfer {
 
 export const parseTransfer = (transaction: EnrichedTransaction): Transfer | EnrichedTransaction => {
     if(transaction.tokenTransfers) {
-        const [ firstTransaction ] = transaction.tokenTransfers;
+        let firstTransaction;
+        let tokenTransferQuantity;
+        let tokenTransferMintAddress;
+
+        if(transaction.tokenTransfers.length === 0 && transaction.nativeTransfers) {
+            [ firstTransaction ] = transaction.nativeTransfers;
+            tokenTransferQuantity = firstTransaction?.amount / LAMPORTS_PER_SOL;
+            tokenTransferMintAddress = "So11111111111111111111111111111111111111112";
+        } else {
+            [ firstTransaction ] = transaction.tokenTransfers;
+            tokenTransferQuantity = firstTransaction?.tokenAmount;
+            tokenTransferMintAddress = firstTransaction?.mint;
+        }
+        
         const sendingUser = firstTransaction?.fromUserAccount;
         const receivingUser = firstTransaction?.toUserAccount;
-        // const tokenTransferName = call a fetch to get the shorten named (ex: SOL, USDC, DeGods #1232)
-        const tokenTransferQuantity = firstTransaction?.tokenAmount;
-        const tokenTransferMintAddress = firstTransaction?.mint;
         const { source, timestamp } = transaction;
 
         return {


### PR DESCRIPTION
- Transfer parsing function is able to also parse native transfers (aka SOL)

In the native transfers conditional statement, I set the tokenTransferMintAddress like this:
```
tokenTransferMintAddress = "So11111111111111111111111111111111111111112";
```
Mert mentioned that this is wSOL which is a tokenized version since SOL is a coin, not a token. He said it's technically wrong to label SOL as that address and it's up to us to how we want to display SOL (add a conditional for displaying it, etc).