### PR TITLE
feat: native token transfers by scammo

### DIFF
--- a/packages/proton/src/parsers/transfer.ts
+++ b/packages/proton/src/parsers/transfer.ts
@@ -1,4 +1,5 @@
-import { EnrichedTransaction, Source } from "@helius/types";
+import { LAMPORTS_PER_SOL } from "@solana/web3.js";
+import type { EnrichedTransaction, Source } from "@helius/types";
 
 interface Transfer {
     sendingUser: string | null,
@@ -11,12 +12,22 @@ interface Transfer {
 
 export const parseTransfer = (transaction: EnrichedTransaction): Transfer | EnrichedTransaction => {
     if(transaction.tokenTransfers) {
-        const [ firstTransaction ] = transaction.tokenTransfers;
+        let firstTransaction;
+        let tokenTransferQuantity;
+        let tokenTransferMintAddress;
+
+        if(transaction.tokenTransfers.length === 0 && transaction.nativeTransfers) {
+            [ firstTransaction ] = transaction.nativeTransfers;
+            tokenTransferQuantity = firstTransaction?.amount / LAMPORTS_PER_SOL;
+            tokenTransferMintAddress = "So11111111111111111111111111111111111111112";
+        } else {
+            [ firstTransaction ] = transaction.tokenTransfers;
+            tokenTransferQuantity = firstTransaction?.tokenAmount;
+            tokenTransferMintAddress = firstTransaction?.mint;
+        }
+        
         const sendingUser = firstTransaction?.fromUserAccount;
         const receivingUser = firstTransaction?.toUserAccount;
-        // const tokenTransferName = call a fetch to get the shorten named (ex: SOL, USDC, DeGods #1232)
-        const tokenTransferQuantity = firstTransaction?.tokenAmount;
-        const tokenTransferMintAddress = firstTransaction?.mint;
         const { source, timestamp } = transaction;
 
         return {


### PR DESCRIPTION
- Transfer parsing function is able to also parse native transfers (aka SOL)

In the native transfers conditional statement, I set the tokenTransferMintAddress like this:
```
tokenTransferMintAddress = "So11111111111111111111111111111111111111112";
```
Mert mentioned that this is wSOL which is a tokenized version since SOL is a coin, not a token. He said it's technically wrong to label SOL as that address and it's up to us to how we want to display SOL (add a conditional for displaying it, etc).