### PR TITLE
Fixes/search recents menu

### DIFF
--- a/apps/web/src/lib/components/search.svelte
+++ b/apps/web/src/lib/components/search.svelte
@@ -71,9 +71,19 @@
         if (!recent.includes(value)) {
             window.localStorage?.setItem(
                 "xray:recent-searches",
-                JSON.stringify([value, ...recentJson.slice(0, 5)])
+                JSON.stringify([value, ...recentJson.slice(0, 3)])
+            );
+        } else {
+            window.localStorage?.setItem(
+                "xray:recent-searches",
+                JSON.stringify([value, ...recentJson.filter((v:string) => v !== value)])
             );
         }
+    };
+
+    const clearRecents = () => {
+        window.localStorage?.setItem("xray:recent-searches", []);
+        recent = [];
     };
 
     const newSearch = async () => {
@@ -174,16 +184,23 @@
             type="text"
             bind:value={inputValue}
         />
+        {#if recent.length > 1}
         <ul
-            class="dropdown-content relative mt-3 w-full rounded-lg border bg-base-100 p-2 px-4 shadow"
+            class="dropdown-content relative my-3 w-full rounded-lg border bg-base-100 p-2 px-4 shadow"
         >
             <div class="flex flex-wrap items-center justify-between">
-                <p class="text-md mb-1 mt-2 font-bold">Recents</p>
+                <p class="text-md mb-1 mt-2">Recents</p>
+                <button
+                    class="btn-xs btn bg-transparent border-none"
+                    on:click={clearRecents}
+                >
+                    <span class="my-1">Clear all</span>
+                </button>
             </div>
             {#if recent.length}
                 {#each recent as address}
                     {#if address}
-                        <li class="m1-ds2 relative z-30 w-full truncate px-0">
+                        <li class="m1-ds2 relative z-30 w-full truncate px-0 hover:opacity-60">
                             <a
                                 class="block w-full max-w-full text-ellipsis px-1 py-2"
                                 data-sveltekit-preload-data="hover"
@@ -209,6 +226,7 @@
                 >
             {/if}
         </ul>
+        {/if}
     </div>
 
     <button

--- a/apps/web/src/lib/components/search.svelte
+++ b/apps/web/src/lib/components/search.svelte
@@ -205,6 +205,7 @@
                                 class="block w-full max-w-full text-ellipsis px-1 py-2"
                                 data-sveltekit-preload-data="hover"
                                 href="/{address}"
+                                on:click={addRecent(address)}
                             >
                                 <p class="text-micro text-xs opacity-50">
                                     {nameFromString(address)}

--- a/packages/helius-namor/src/index.ts
+++ b/packages/helius-namor/src/index.ts
@@ -12,8 +12,8 @@ import { publicKeyMappings } from "./types";
 
 export const nameFromString = (str: string) =>
     uniqueNamesGenerator({
-        dictionaries: [colors, adjectives, colors, animals],
-        length: 4,
+        dictionaries: [colors, adjectives, colors, animals, names],
+        length: 5,
         seed: str + "namor",
         separator: " ",
         style: "capital",

--- a/packages/helius-namor/src/index.ts
+++ b/packages/helius-namor/src/index.ts
@@ -12,8 +12,13 @@ import { publicKeyMappings } from "./types";
 
 export const nameFromString = (str: string) =>
     uniqueNamesGenerator({
-        dictionaries: [colors, adjectives, colors, animals, names],
-        length: 5,
+        dictionaries: [
+            [...colors, ...names],
+            adjectives,
+            colors,
+            [...animals, ...names],
+        ],
+        length: 4,
         seed: str + "namor",
         separator: " ",
         style: "capital",


### PR DESCRIPTION
- Added another dictionary to uniqueNamesGenerator config to avoid identical names for wallets
- Updated Recent ids on search component to address following:
- Only shows this dropdown if there are 2 or more recent tx/wallet/tokens
- Limits number of recent Ids to 4
- Only saves unique ids to avoid doubles of same id
- Added clear all button to clear all recent ids
- Added hover states for recent ids