### PR TITLE
fix: labels 

### DIFF
--- a/apps/web/src/lib/components/transaction.svelte
+++ b/apps/web/src/lib/components/transaction.svelte
@@ -1,8 +1,10 @@
 <script lang="ts">
     import type {
         ProtonActionType,
-        ProtonTransaction,
+        ProtonTransaction
     } from "@helius-labs/xray-proton";
+
+    import { ProtonCustomActionLabelTypes } from "@helius-labs/xray-proton";
 
     import { page } from "$app/stores";
 
@@ -191,8 +193,22 @@
                                                         {metadata?.name ||
                                                             "Unknown"}
                                                     </h4>
-
-                                                    {#if !action?.actionType?.includes("NFT")}
+                                                    {#if Object.keys(ProtonCustomActionLabelTypes).includes(action.actionType)}
+                                                        <h3
+                                                            class="ml-2 text-xs"
+                                                        >
+                                                            <button
+                                                                on:click|self={() =>
+                                                                    (window.location.href = `/${action.from}/wallet`)}
+                                                                class="link-neutral pointer-events-auto border border-x-0 border-t-0 border-dotted hover:link-success"
+                                                            >
+                                                                {transactionActionsMetadata[
+                                                                    action
+                                                                        ?.actionType
+                                                                ].label}
+                                                            </button>
+                                                        </h3>
+                                                    {:else if !action?.actionType?.includes("NFT")}
                                                         <div class="flex">
                                                             {#if action?.actionType?.includes("SENT") && action.to}
                                                                 <p

--- a/apps/web/src/lib/config.ts
+++ b/apps/web/src/lib/config.ts
@@ -43,7 +43,7 @@ export const transactionActionsMetadata: Record<
     },
     FREEZE: {
         icon: "cold",
-        label: "Froze",
+        label: "Frozen",
     },
     LOAN_FOX: {
         icon: "handshake",

--- a/apps/web/src/lib/config.ts
+++ b/apps/web/src/lib/config.ts
@@ -31,11 +31,11 @@ export const transactionActionsMetadata: Record<
     },
     BURN: {
         icon: "flame",
-        label: "Burn",
+        label: "Burned",
     },
     BURN_NFT: {
         icon: "flame",
-        label: "Burn NFT",
+        label: "Burned NFT",
     },
     EXECUTE_TRANSACTION: {
         icon: "lightning",
@@ -43,7 +43,7 @@ export const transactionActionsMetadata: Record<
     },
     FREEZE: {
         icon: "cold",
-        label: "Freeze",
+        label: "Froze",
     },
     LOAN_FOX: {
         icon: "handshake",

--- a/apps/web/src/lib/config.ts
+++ b/apps/web/src/lib/config.ts
@@ -1,4 +1,4 @@
-import type { TransactionActionMetadata, Modal } from "$lib/types";
+import type { Modal, TransactionActionMetadata } from "$lib/types";
 import type { ProtonActionType } from "@helius-labs/xray-proton";
 
 import InvalidSearch from "$lib/components/modals/invalid-search.svelte";
@@ -36,6 +36,10 @@ export const transactionActionsMetadata: Record<
     BURN_NFT: {
         icon: "flame",
         label: "Burn NFT",
+    },
+    EXECUTE_TRANSACTION: {
+        icon: "lightning",
+        label: "Multisig Transaction",
     },
     FREEZE: {
         icon: "cold",

--- a/packages/xray-proton/src/types/index.ts
+++ b/packages/xray-proton/src/types/index.ts
@@ -54,7 +54,7 @@ export const ProtonCustomActionLabelTypes = {
     AIRDROP: "Airdropped",
     BURN: "Burned",
     BURN_NFT: "Burned NFT",
-    FREEZE: "Froze",
+    FREEZE: "Frozen",
 };
 
 export type ProtonParser = (

--- a/packages/xray-proton/src/types/index.ts
+++ b/packages/xray-proton/src/types/index.ts
@@ -47,6 +47,7 @@ export enum ProtonSupportedActionType {
     "TOKEN_MINT",
     "BORROW_FOX",
     "LOAN_FOX",
+    "EXECUTE_TRANSACTION",
 }
 
 export type ProtonParser = (

--- a/packages/xray-proton/src/types/index.ts
+++ b/packages/xray-proton/src/types/index.ts
@@ -50,6 +50,13 @@ export enum ProtonSupportedActionType {
     "EXECUTE_TRANSACTION",
 }
 
+export const ProtonCustomActionLabelTypes = {
+    AIRDROP: "Airdropped",
+    BURN: "Burned",
+    BURN_NFT: "Burned NFT",
+    FREEZE: "Froze",
+};
+
 export type ProtonParser = (
     transaction: EnrichedTransaction,
     address?: string


### PR DESCRIPTION
- squads EXECUTE_TRANSACTION is labeled properly now 
- label for certain tx types show properly (burn, airdrop, etc)