### PR TITLE
fix: nft airdrop label fix

### DIFF
--- a/packages/xray-proton/src/parsers/nft.ts
+++ b/packages/xray-proton/src/parsers/nft.ts
@@ -326,7 +326,7 @@ export const parseNftMint: ProtonParser = (transaction, address) => {
             }
         );
     } else {
-        if (nativeTransfers[0].fromUserAccount !== address) {
+        if (nftEvent.buyer !== address) {
             actions.push({
                 actionType: "AIRDROP",
                 amount: 1,


### PR DESCRIPTION
sometimes when you mint an nft, on wallet view itd show an airdrop even when you minted it