### PR TITLE
chore: add recommendations for vscode and `.env.template` file 

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,0 +1,1 @@
+HELIUS_KEY = ""

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,16 @@
+{
+	// Extension identifier format: ${publisher}.${name}. Example: vscode.csharp
+
+	// List of extensions which should be recommended for users of this workspace.
+	"recommendations": [
+        "aaron-bond.better-comments",
+        "svelte.svelte-vscode",
+        "prisma.prisma",
+        "esbenp.prettier-vscode",
+		"dbaeumer.vscode-eslint",
+	],
+	// List of extensions recommended by VS Code that should not be recommended for users of this workspace.
+	"unwantedRecommendations": [
+		
+	]
+}


### PR DESCRIPTION
Add suggestions for the vscode extensions recommended. 

When a user opens up vscode and he does not have the recommended extensions he will be prompted to install them. 

![Screenshot from 2023-04-24 22-22-24](https://user-images.githubusercontent.com/30603522/234096359-e053e6fd-5c30-4a80-94e1-8b8541d7e35f.png)
