### PR TITLE
Fix current number of leaves on a merkle tree

### DIFF
--- a/src/routes/account/[account]/concurrent-merkle-tree/+page.svelte
+++ b/src/routes/account/[account]/concurrent-merkle-tree/+page.svelte
@@ -238,7 +238,7 @@
                     </h3>
                 </div>
                 <p class="text-xs md:text-sm">
-                    {($cmt.data.rightMostIndex - 1).toLocaleString()}
+                    {($cmt.data.rightMostIndex).toLocaleString()}
                 </p>
             </div>
         </div>


### PR DESCRIPTION
https://xray.helius.xyz/account/3RYFyDBd81h3hQ8P1PtZRgSJYgKeNKXamKJPXhWmy5e7

The number of leaves from the rightMostPath should not be subtracted by 1, as you can see in the link above, 8 cNFTs are minted to the tree however the number of leaves displayed is 7. This error can also be seen by visiting other explorers.