### PR TITLE
[Feature] Add Search By Token Symbol Functionality

### DIFF
--- a/src/lib/components/modals/help.svelte
+++ b/src/lib/components/modals/help.svelte
@@ -6,11 +6,12 @@
         ["globe", ".sol, .abc, .poor, .bonk domains"],
         ["person", "Wallet/Account addresses"],
         ["coins", "Token addresses"],
+        ["dots", "Token symbols (case sensitive)"],
         ["lightning", "Transaction signatures"],
     ];
 </script>
 
-<p class="mb-3">Use the search bar to look up any of the following.</p>
+<p class="mb-3">Use the search bar to look up any of the following:</p>
 
 <strong class="uppercase">Supported Searches</strong>
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -111,3 +111,7 @@ export interface JupiterToken {
 export interface TokenMap {
     [symbol: string]: string;
 }
+
+export type RecognizedTokens = {
+    [key: string]: string;
+};

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -99,3 +99,15 @@ export interface Modal {
 export type Modals = keyof typeof modals;
 
 export type NullableProp<T> = T | null | undefined;
+
+export interface JupiterToken {
+    name: string;
+    symbol: string;
+    address: string;
+    decimals: number;
+    logoURI: string;
+}
+
+export interface TokenMap {
+    [symbol: string]: string;
+}

--- a/src/lib/util/get-tokens.ts
+++ b/src/lib/util/get-tokens.ts
@@ -1,4 +1,3 @@
-import fetch from "node-fetch";
 import type { JupiterToken, TokenMap } from "$lib/types";
 
 const getJupiterTokens = async (): Promise<TokenMap> => {

--- a/src/lib/util/get-tokens.ts
+++ b/src/lib/util/get-tokens.ts
@@ -1,0 +1,25 @@
+import fetch from "node-fetch";
+import type { JupiterToken, TokenMap } from "$lib/types";
+
+const getJupiterTokens = async (): Promise<TokenMap> => {
+    try {
+        const data = await fetch(`https://token.jup.ag/all`);
+        const jsonData = await data.json();
+
+        if (!Array.isArray(jsonData)) {
+            throw new Error("Unexpected data format from Jupiter API");
+        }
+
+        const tokens: JupiterToken[] = jsonData as JupiterToken[];
+        const tokenMap = tokens.reduce((acc: TokenMap, token: JupiterToken) => {
+            acc[token.symbol] = token.address;
+            return acc;
+        }, {});
+
+        return tokenMap;
+    } catch (error: any) {
+        throw new Error("Failed to fetch tokens from Jupiter");
+    }
+};
+
+export default getJupiterTokens;

--- a/src/lib/util/get-tokens.ts
+++ b/src/lib/util/get-tokens.ts
@@ -1,4 +1,5 @@
 import type { JupiterToken, TokenMap } from "$lib/types";
+import { recognizedTokens } from "./recognized-tokens";
 
 const getJupiterTokens = async (): Promise<TokenMap> => {
     try {
@@ -11,13 +12,21 @@ const getJupiterTokens = async (): Promise<TokenMap> => {
 
         const tokens: JupiterToken[] = jsonData as JupiterToken[];
         const tokenMap = tokens.reduce((acc: TokenMap, token: JupiterToken) => {
-            acc[token.symbol] = token.address;
+            if (
+                (recognizedTokens[token.symbol] &&
+                    recognizedTokens[token.symbol] === token.address) ||
+                !recognizedTokens[token.symbol]
+            ) {
+                acc[token.symbol] = token.address;
+            }
             return acc;
         }, {});
 
         return tokenMap;
     } catch (error: any) {
-        throw new Error("Failed to fetch tokens from Jupiter");
+        throw new Error(
+            `Failed to fetch tokens from Jupiter with error: ${error}`
+        );
     }
 };
 

--- a/src/lib/util/recognized-tokens.ts
+++ b/src/lib/util/recognized-tokens.ts
@@ -1,0 +1,6 @@
+import type { RecognizedTokens } from "$lib/types";
+
+export const recognizedTokens: RecognizedTokens = {
+    FOXY: "FoXyMu5xwXre7zEoSvzViRk3nGawHUp9kUh97y2NDhcq",
+    USDC: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+};

--- a/src/lib/xray/lib/search.ts
+++ b/src/lib/xray/lib/search.ts
@@ -137,9 +137,6 @@ export const search = async (
             valid: true,
         };
     } else if (Object.keys(tokenSymbols).find((key) => key === query)) {
-        //eslint-disable-next-line
-        // There's an issue with USDC having the same symbol as the wormhole USDC shit - check that out
-        //console.log(tokenSymbols[query]);
         return {
             address: tokenSymbols[query],
             search: query,

--- a/src/lib/xray/lib/search.ts
+++ b/src/lib/xray/lib/search.ts
@@ -136,7 +136,10 @@ export const search = async (
             url: `/account/${owner}`,
             valid: true,
         };
-    } else if (tokenSymbols.hasOwnProperty(query)) {
+    } else if (Object.keys(tokenSymbols).find((key) => key === query)) {
+        //eslint-disable-next-line
+        // There's an issue with USDC having the same symbol as the wormhole USDC shit - check that out
+        //console.log(tokenSymbols[query]);
         return {
             address: tokenSymbols[query],
             search: query,

--- a/src/lib/xray/lib/search.ts
+++ b/src/lib/xray/lib/search.ts
@@ -6,6 +6,8 @@ import { PublicKey } from "@solana/web3.js";
 
 import { TldParser } from "@onsol/tldparser";
 
+import getJupiterTokens from "$lib/util/get-tokens";
+
 export interface SearchResult {
     url: string;
     address: string;
@@ -44,6 +46,9 @@ export const search = async (
     const probablyAnsDomain = query.length > 4 && query.includes(".");
 
     const probablyBackpackName = query.startsWith("@") && query.length > 1;
+
+    // For token symbols
+    const tokenSymbols = await getJupiterTokens();
 
     if (isValidPublicKey(query)) {
         const pubkey = new PublicKey(query);
@@ -129,6 +134,14 @@ export const search = async (
             search: query,
             type: "ans-domain",
             url: `/account/${owner}`,
+            valid: true,
+        };
+    } else if (tokenSymbols.hasOwnProperty(query)) {
+        return {
+            address: tokenSymbols[query],
+            search: query,
+            type: "token",
+            url: `/token/${tokenSymbols[query]}`,
             valid: true,
         };
     }

--- a/src/lib/xray/lib/search.ts
+++ b/src/lib/xray/lib/search.ts
@@ -1,6 +1,6 @@
 import { isValidPublicKey } from "../index";
 
-import { Connection } from "@solana/web3.js";
+import type { Connection } from "@solana/web3.js";
 
 import { PublicKey } from "@solana/web3.js";
 

--- a/src/routes/account/[account]/concurrent-merkle-tree/+page.svelte
+++ b/src/routes/account/[account]/concurrent-merkle-tree/+page.svelte
@@ -238,7 +238,7 @@
                     </h3>
                 </div>
                 <p class="text-xs md:text-sm">
-                    {$cmt.data.rightMostIndex.toLocaleString()}
+                    {($cmt.data.rightMostIndex).toLocaleString()}
                 </p>
             </div>
         </div>

--- a/src/routes/account/[account]/concurrent-merkle-tree/+page.svelte
+++ b/src/routes/account/[account]/concurrent-merkle-tree/+page.svelte
@@ -238,7 +238,7 @@
                     </h3>
                 </div>
                 <p class="text-xs md:text-sm">
-                    {($cmt.data.rightMostIndex).toLocaleString()}
+                    {$cmt.data.rightMostIndex.toLocaleString()}
                 </p>
             </div>
         </div>


### PR DESCRIPTION
The goal of this PR is to allow users to search for token addresses using their token symbol. For example, if a user wanted to look up "USDC" then they could simply search for USDC instead of searching for EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v. Here, our search functionality uses the Jupiter Token API to fetch common SPL token symbols and their respective addresses. We then check the user's query against this list of tokens, and direct them to the proper token address page on Xray

This would allow users to check if an address is genuine and not a scam address. This also partly addresses #175  by allowing users to search by token names