### PR TITLE
[Feature] Add Video Support

### DIFF
--- a/src/lib/components/modals/help.svelte
+++ b/src/lib/components/modals/help.svelte
@@ -6,11 +6,12 @@
         ["globe", ".sol, .abc, .poor, .bonk domains"],
         ["person", "Wallet/Account addresses"],
         ["coins", "Token addresses"],
+        ["dots", "Token symbols (case sensitive)"],
         ["lightning", "Transaction signatures"],
     ];
 </script>
 
-<p class="mb-3">Use the search bar to look up any of the following.</p>
+<p class="mb-3">Use the search bar to look up any of the following:</p>
 
 <strong class="uppercase">Supported Searches</strong>
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -111,3 +111,7 @@ export interface JupiterToken {
 export interface TokenMap {
     [symbol: string]: string;
 }
+
+export type RecognizedTokens = {
+    [key: string]: string;
+};

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -99,3 +99,15 @@ export interface Modal {
 export type Modals = keyof typeof modals;
 
 export type NullableProp<T> = T | null | undefined;
+
+export interface JupiterToken {
+    name: string;
+    symbol: string;
+    address: string;
+    decimals: number;
+    logoURI: string;
+}
+
+export interface TokenMap {
+    [symbol: string]: string;
+}

--- a/src/lib/util/get-mime-type.ts
+++ b/src/lib/util/get-mime-type.ts
@@ -1,18 +1,6 @@
-const getMimeType = (filename: string): string | null => {
-    const parts = filename.split(".");
-    const extension = parts.length > 1 ? parts.pop()!.toLowerCase() : null;
-
-    if (extension === "mp4") {
-        return "video/mp4";
-    } else if (extension === "webm") {
-        return "video/webm";
-    } else if (extension === "ogg") {
-        return "video/ogg";
-    } else if (extension === "mov") {
-        return "video/quicktime";
-    } else {
-        return null;
-    }
+const getMimeType = async (url: string) => {
+    const response = await fetch(url, { method: "HEAD" });
+    return response.headers.get("Content-Type");
 };
 
 export default getMimeType;

--- a/src/lib/util/get-mime-type.ts
+++ b/src/lib/util/get-mime-type.ts
@@ -1,0 +1,18 @@
+const getMimeType = (filename: string): string | null => {
+    const parts = filename.split(".");
+    const extension = parts.length > 1 ? parts.pop()!.toLowerCase() : null;
+
+    if (extension === "mp4") {
+        return "video/mp4";
+    } else if (extension === "webm") {
+        return "video/webm";
+    } else if (extension === "ogg") {
+        return "video/ogg";
+    } else if (extension === "mov") {
+        return "video/quicktime";
+    } else {
+        return null;
+    }
+};
+
+export default getMimeType;

--- a/src/lib/util/get-tokens.ts
+++ b/src/lib/util/get-tokens.ts
@@ -1,4 +1,3 @@
-import fetch from "node-fetch";
 import type { JupiterToken, TokenMap } from "$lib/types";
 
 const getJupiterTokens = async (): Promise<TokenMap> => {

--- a/src/lib/util/get-tokens.ts
+++ b/src/lib/util/get-tokens.ts
@@ -1,0 +1,25 @@
+import fetch from "node-fetch";
+import type { JupiterToken, TokenMap } from "$lib/types";
+
+const getJupiterTokens = async (): Promise<TokenMap> => {
+    try {
+        const data = await fetch(`https://token.jup.ag/all`);
+        const jsonData = await data.json();
+
+        if (!Array.isArray(jsonData)) {
+            throw new Error("Unexpected data format from Jupiter API");
+        }
+
+        const tokens: JupiterToken[] = jsonData as JupiterToken[];
+        const tokenMap = tokens.reduce((acc: TokenMap, token: JupiterToken) => {
+            acc[token.symbol] = token.address;
+            return acc;
+        }, {});
+
+        return tokenMap;
+    } catch (error: any) {
+        throw new Error("Failed to fetch tokens from Jupiter");
+    }
+};
+
+export default getJupiterTokens;

--- a/src/lib/util/get-tokens.ts
+++ b/src/lib/util/get-tokens.ts
@@ -1,4 +1,5 @@
 import type { JupiterToken, TokenMap } from "$lib/types";
+import { recognizedTokens } from "./recognized-tokens";
 
 const getJupiterTokens = async (): Promise<TokenMap> => {
     try {
@@ -11,13 +12,21 @@ const getJupiterTokens = async (): Promise<TokenMap> => {
 
         const tokens: JupiterToken[] = jsonData as JupiterToken[];
         const tokenMap = tokens.reduce((acc: TokenMap, token: JupiterToken) => {
-            acc[token.symbol] = token.address;
+            if (
+                (recognizedTokens[token.symbol] &&
+                    recognizedTokens[token.symbol] === token.address) ||
+                !recognizedTokens[token.symbol]
+            ) {
+                acc[token.symbol] = token.address;
+            }
             return acc;
         }, {});
 
         return tokenMap;
     } catch (error: any) {
-        throw new Error("Failed to fetch tokens from Jupiter");
+        throw new Error(
+            `Failed to fetch tokens from Jupiter with error: ${error}`
+        );
     }
 };
 

--- a/src/lib/util/recognized-tokens.ts
+++ b/src/lib/util/recognized-tokens.ts
@@ -1,0 +1,6 @@
+import type { RecognizedTokens } from "$lib/types";
+
+export const recognizedTokens: RecognizedTokens = {
+    FOXY: "FoXyMu5xwXre7zEoSvzViRk3nGawHUp9kUh97y2NDhcq",
+    USDC: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+};

--- a/src/lib/xray/lib/search.ts
+++ b/src/lib/xray/lib/search.ts
@@ -137,9 +137,6 @@ export const search = async (
             valid: true,
         };
     } else if (Object.keys(tokenSymbols).find((key) => key === query)) {
-        //eslint-disable-next-line
-        // There's an issue with USDC having the same symbol as the wormhole USDC shit - check that out
-        //console.log(tokenSymbols[query]);
         return {
             address: tokenSymbols[query],
             search: query,

--- a/src/lib/xray/lib/search.ts
+++ b/src/lib/xray/lib/search.ts
@@ -136,7 +136,10 @@ export const search = async (
             url: `/account/${owner}`,
             valid: true,
         };
-    } else if (tokenSymbols.hasOwnProperty(query)) {
+    } else if (Object.keys(tokenSymbols).find((key) => key === query)) {
+        //eslint-disable-next-line
+        // There's an issue with USDC having the same symbol as the wormhole USDC shit - check that out
+        //console.log(tokenSymbols[query]);
         return {
             address: tokenSymbols[query],
             search: query,

--- a/src/lib/xray/lib/search.ts
+++ b/src/lib/xray/lib/search.ts
@@ -6,6 +6,8 @@ import { PublicKey } from "@solana/web3.js";
 
 import { TldParser } from "@onsol/tldparser";
 
+import getJupiterTokens from "$lib/util/get-tokens";
+
 export interface SearchResult {
     url: string;
     address: string;
@@ -44,6 +46,9 @@ export const search = async (
     const probablyAnsDomain = query.length > 4 && query.includes(".");
 
     const probablyBackpackName = query.startsWith("@") && query.length > 1;
+
+    // For token symbols
+    const tokenSymbols = await getJupiterTokens();
 
     if (isValidPublicKey(query)) {
         const pubkey = new PublicKey(query);
@@ -129,6 +134,14 @@ export const search = async (
             search: query,
             type: "ans-domain",
             url: `/account/${owner}`,
+            valid: true,
+        };
+    } else if (tokenSymbols.hasOwnProperty(query)) {
+        return {
+            address: tokenSymbols[query],
+            search: query,
+            type: "token",
+            url: `/token/${tokenSymbols[query]}`,
             valid: true,
         };
     }

--- a/src/lib/xray/lib/search.ts
+++ b/src/lib/xray/lib/search.ts
@@ -1,6 +1,6 @@
 import { isValidPublicKey } from "../index";
 
-import { Connection } from "@solana/web3.js";
+import type { Connection } from "@solana/web3.js";
 
 import { PublicKey } from "@solana/web3.js";
 

--- a/src/routes/account/[account]/concurrent-merkle-tree/+page.svelte
+++ b/src/routes/account/[account]/concurrent-merkle-tree/+page.svelte
@@ -238,7 +238,7 @@
                     </h3>
                 </div>
                 <p class="text-xs md:text-sm">
-                    {$cmt.data.rightMostIndex.toLocaleString()}
+                    {($cmt.data.rightMostIndex).toLocaleString()}
                 </p>
             </div>
         </div>

--- a/src/routes/account/[account]/concurrent-merkle-tree/+page.svelte
+++ b/src/routes/account/[account]/concurrent-merkle-tree/+page.svelte
@@ -238,7 +238,7 @@
                     </h3>
                 </div>
                 <p class="text-xs md:text-sm">
-                    {($cmt.data.rightMostIndex).toLocaleString()}
+                    {$cmt.data.rightMostIndex.toLocaleString()}
                 </p>
             </div>
         </div>

--- a/src/routes/token/[token]/+page.svelte
+++ b/src/routes/token/[token]/+page.svelte
@@ -11,7 +11,7 @@
     }
 
     .img {
-        max-height: 25vh;
+        max-height: 65vh;
     }
 </style>
 
@@ -30,6 +30,8 @@
 
     import CopyButton from "$lib/components/copy-button.svelte";
     import TokenProvider from "$lib/components/providers/token-provider.svelte";
+
+    import getMimeType from "$lib/util/get-mime-type";
 
     const address = $page.params.token;
 </script>
@@ -71,12 +73,35 @@
                 class="flex flex-col items-center justify-center"
                 in:fade={{ delay: 100, duration: 800 }}
             >
-                <img
-                    class="img m-auto my-3 h-auto w-full rounded-md object-contain"
-                    alt="token symbol"
-                    src={metadata.image}
-                    in:fade={{ delay: 600, duration: 1000 }}
-                />
+                {#await getMimeType(metadata.image)}
+                    <div>Loading...</div>
+                {:then mimeType}
+                    {#if mimeType && mimeType.startsWith("video")}
+                        <video
+                            class="m-auto my-3 h-auto w-full rounded-md object-contain"
+                            controls
+                            autoplay
+                            loop
+                            muted
+                            in:fade={{ delay: 600, duration: 1000 }}
+                        >
+                            <source
+                                src={metadata.image}
+                                type={mimeType}
+                            />
+                            Your browser does not support the video tag.
+                        </video>
+                    {:else}
+                        <img
+                            class="img m-auto my-3 h-auto w-full rounded-md object-contain"
+                            alt="token symbol"
+                            src={metadata.image}
+                            in:fade={{ delay: 600, duration: 1000 }}
+                        />
+                    {/if}
+                {:catch error}
+                    <div>Error loading MIME type: {error.message}</div>
+                {/await}
             </div>
 
             {#if metadata.description}


### PR DESCRIPTION
The goal of this PR is to enhance the media rendering capabilities of Xray by adding video support. Currently, we display a token's image using an `<img>` tag. This works well for images but not videos as support varies across different browsers. For instance, if a cNFT has a `.mp4` file set as its image in its metadata, it won't play on Firefox but it will on Safari

To address this, we fetch the MIME type of the metadata's image URL. If the mime type starts with "video", we render the metadata's image (which, in this case, is a video) using the `<video>` tag. If the MIME type does not indicate a video then we fall back to using the `<img>` tag, which ensures we still render images properly