### PR TITLE
[Feature] Add Video Support

### DIFF
--- a/src/lib/components/providers/token-provider.svelte
+++ b/src/lib/components/providers/token-provider.svelte
@@ -119,6 +119,7 @@
             data?.legacyMetadata?.name ||
             data?.onChainMetadata?.metadata?.data.name;
         metadata.files = data?.offChainMetadata?.metadata?.properties?.files;
+        // Checking all files to see if a video exists
         metadata.video_uri =
             data?.offChainMetadata?.metadata?.properties?.files?.find(
                 (file: any) => file.type.startsWith("video/")

--- a/src/lib/components/providers/token-provider.svelte
+++ b/src/lib/components/providers/token-provider.svelte
@@ -118,6 +118,11 @@
             data?.offChainMetadata?.metadata?.name ||
             data?.legacyMetadata?.name ||
             data?.onChainMetadata?.metadata?.data.name;
+        metadata.files = data?.offChainMetadata?.metadata?.properties?.files;
+        metadata.video_uri =
+            data?.offChainMetadata?.metadata?.properties?.files?.find(
+                (file: any) => file.type.startsWith("video/")
+            )?.uri;
     }
 
     $: tokenIsLoading = address !== SOL && $token.isLoading;

--- a/src/lib/components/providers/token-provider.svelte
+++ b/src/lib/components/providers/token-provider.svelte
@@ -44,7 +44,7 @@
         },
     };
 
-    const metadata: UITokenMetadata = {
+    export const metadata: UITokenMetadata = {
         address: "",
         attributes: [],
         collectionKey: "",

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -39,6 +39,12 @@ export interface UITokenMetadataCreators {
     share: number;
     verified: boolean;
 }
+
+export interface FileProperties {
+    type: string;
+    uri: string;
+}
+
 export interface UITokenMetadata {
     address: string;
     image: string;
@@ -60,6 +66,8 @@ export interface UITokenMetadata {
     tree?: string;
     seq?: number;
     leafId?: number;
+    files?: FileProperties[];
+    video_uri?: string;
 }
 
 export type Icon = keyof typeof IconPaths;

--- a/src/lib/util/get-mime-type.ts
+++ b/src/lib/util/get-mime-type.ts
@@ -1,6 +1,17 @@
+/* eslint-disable no-console */
 const getMimeType = async (url: string) => {
-    const response = await fetch(url, { method: "HEAD" });
-    return response.headers.get("Content-Type");
+    try {
+        const response = await fetch(url, { method: "HEAD" });
+        if (!response.ok) {
+            console.error(
+                `Failed to fetch MIME type: ${response.status} ${response.statusText}`
+            );
+            return null;
+        }
+        return response.headers.get("Content-Type");
+    } catch (error: any) {
+        return null;
+    }
 };
 
 export default getMimeType;

--- a/src/lib/util/get-mime-type.ts
+++ b/src/lib/util/get-mime-type.ts
@@ -1,0 +1,6 @@
+const getMimeType = async (url: string) => {
+    const response = await fetch(url, { method: "HEAD" });
+    return response.headers.get("Content-Type");
+};
+
+export default getMimeType;

--- a/src/lib/util/stores/metadata.ts
+++ b/src/lib/util/stores/metadata.ts
@@ -1,0 +1,4 @@
+import type { UITokenMetadata } from "$lib/types";
+import { writable } from "svelte/store";
+
+export const metadataStore = writable(null);

--- a/src/lib/util/stores/metadata.ts
+++ b/src/lib/util/stores/metadata.ts
@@ -1,4 +1,4 @@
 import type { UITokenMetadata } from "$lib/types";
 import { writable } from "svelte/store";
 
-export const metadataStore = writable(null);
+export const metadataStore = writable<UITokenMetadata | null>(null);

--- a/src/routes/account/[account]/concurrent-merkle-tree/+page.svelte
+++ b/src/routes/account/[account]/concurrent-merkle-tree/+page.svelte
@@ -238,7 +238,7 @@
                     </h3>
                 </div>
                 <p class="text-xs md:text-sm">
-                    {($cmt.data.rightMostIndex).toLocaleString()}
+                    {$cmt.data.rightMostIndex.toLocaleString()}
                 </p>
             </div>
         </div>

--- a/src/routes/token/[token]/+page.svelte
+++ b/src/routes/token/[token]/+page.svelte
@@ -65,7 +65,6 @@
             <PageLoader />
         </div>
     {:else}
-        {metadataStore.set(metadata)}
         <div class="nav content sticky top-14 z-30 bg-base-100 px-3 py-2">
             <div
                 class="relative flex flex-wrap items-center justify-between bg-base-100"

--- a/src/routes/token/[token]/+page.svelte
+++ b/src/routes/token/[token]/+page.svelte
@@ -11,7 +11,7 @@
     }
 
     .img {
-        max-height: 65vh;
+        max-height: 55vh;
     }
 </style>
 
@@ -37,8 +37,6 @@
 
     const address = $page.params.token;
 
-    let mimeType: string | null = null;
-    let loadingMimeType: boolean = true;
     let metadata: UITokenMetadata;
 
     let mediaUrl: string | null = null;
@@ -65,21 +63,6 @@
             }
         }
     };
-
-    // metadataStore.subscribe((value) => {
-    //     if (value && value.image) {
-    //         loadingMimeType = true;
-    //         getMimeType(value.image)
-    //             // eslint-disable-next-line promise/always-return
-    //             .then((type) => {
-    //                 mimeType = type;
-    //                 loadingMimeType = false;
-    //             })
-    //             .catch(() => {
-    //                 loadingMimeType = false;
-    //             });
-    //     }
-    // });
 
     metadataStore.subscribe((metadata) => {
         if (metadata) setMedia(metadata);
@@ -143,7 +126,7 @@
                     <img
                         class="img m-auto my-3 h-auto w-full rounded-md object-contain"
                         alt="token symbol"
-                        src={metadata.image}
+                        src={mediaUrl}
                         in:fade={{ delay: 600, duration: 1000 }}
                     />
                 {:else}

--- a/src/routes/token/[token]/+page.svelte
+++ b/src/routes/token/[token]/+page.svelte
@@ -11,7 +11,7 @@
     }
 
     .img {
-        max-height: 25vh;
+        max-height: 65vh;
     }
 </style>
 
@@ -30,6 +30,8 @@
 
     import CopyButton from "$lib/components/copy-button.svelte";
     import TokenProvider from "$lib/components/providers/token-provider.svelte";
+
+    import getMimeType from "$lib/util/get-mime-type";
 
     const address = $page.params.token;
 </script>
@@ -71,12 +73,35 @@
                 class="flex flex-col items-center justify-center"
                 in:fade={{ delay: 100, duration: 800 }}
             >
+            {#await getMimeType(metadata.image)}
+            <div>Loading...</div>
+        {:then mimeType}
+            {#if mimeType && mimeType.startsWith("video")}
+                <video
+                    class="m-auto my-3 h-auto w-full rounded-md object-contain"
+                    controls
+                    autoplay
+                    loop
+                    muted
+                    in:fade={{ delay: 600, duration: 1000 }}
+                >
+                    <source
+                        src={metadata.image}
+                        type={mimeType}
+                    />
+                    Your browser does not support the video tag.
+                </video>
+            {:else}
                 <img
                     class="img m-auto my-3 h-auto w-full rounded-md object-contain"
                     alt="token symbol"
                     src={metadata.image}
                     in:fade={{ delay: 600, duration: 1000 }}
                 />
+            {/if}
+        {:catch error}
+            <div>Error loading MIME type: {error.message}</div>
+        {/await}
             </div>
 
             {#if metadata.description}

--- a/src/routes/token/[token]/+page.svelte
+++ b/src/routes/token/[token]/+page.svelte
@@ -39,20 +39,20 @@
     let mimeType: string | null = null;
     let loadingMimeType: boolean = true;
 
-    metadataStore.subscribe(value => {
+    metadataStore.subscribe((value) => {
         if (value && value.image) {
             loadingMimeType = true;
             getMimeType(value.image)
                 // eslint-disable-next-line promise/always-return
-                .then(type => {
+                .then((type) => {
                     mimeType = type;
                     loadingMimeType = false;
                 })
                 .catch(() => {
                     loadingMimeType = false;
-                })
+                });
         }
-    })
+    });
 </script>
 
 <TokenProvider
@@ -93,10 +93,9 @@
                 class="flex flex-col items-center justify-center"
                 in:fade={{ delay: 100, duration: 800 }}
             >
-            {#if loadingMimeType}
-                <div>Loading...</div>
-            {:else}
-                {#if mimeType && mimeType.startsWith("video")}
+                {#if loadingMimeType}
+                    <div>Loading...</div>
+                {:else if mimeType && mimeType.startsWith("video")}
                     <!-- Video tag -->
                     <video
                         class="m-auto my-3 h-auto w-full rounded-md object-contain"
@@ -105,13 +104,8 @@
                         loop
                         muted
                         in:fade={{ delay: 600, duration: 1000 }}
-                    >
-                        <source
-                            src={metadata.image}
-                            type={mimeType}
-                        />
-                        Your browser does not support the video tag.
-                    </video>
+                        src={metadata.image}
+                    />
                 {:else}
                     <!-- Image tag -->
                     <img
@@ -121,7 +115,6 @@
                         in:fade={{ delay: 600, duration: 1000 }}
                     />
                 {/if}
-            {/if}
             </div>
 
             {#if metadata.description}

--- a/src/routes/token/[token]/+page.svelte
+++ b/src/routes/token/[token]/+page.svelte
@@ -33,11 +33,13 @@
 
     import getMimeType from "$lib/util/get-mime-type";
     import { metadataStore } from "$lib/util/stores/metadata";
+    import type { UITokenMetadata } from "$lib/types";
 
     const address = $page.params.token;
 
     let mimeType: string | null = null;
     let loadingMimeType: boolean = true;
+    let metadata: UITokenMetadata;
 
     metadataStore.subscribe((value) => {
         if (value && value.image) {
@@ -53,11 +55,15 @@
                 });
         }
     });
+
+    $: if (metadata) {
+        metadataStore.set(metadata);
+    }
 </script>
 
 <TokenProvider
     {address}
-    let:metadata
+    bind:metadata={metadata}
     let:tokenIsLoading
 >
     {#if tokenIsLoading}


### PR DESCRIPTION
The goal of this PR is to enhance the media rendering capabilities of Xray by adding video support. Currently, we display a token's image using an `<img>` tag. This works well for images but not videos as support varies across different browsers. For instance, if a cNFT has a `.mp4` file set as its image in its metadata, it won't play on Firefox but it will on Safari

To address this, we fetch the MIME type of the metadata's image URL. If the MIME type starts with "video", we render the metadata's image (which, in this case, is a video) using the `<video>` tag. If the MIME type does not indicate a video then we fall back to using the `<img>` tag, which ensures we still render images properly