### PR TITLE
[Bug] Fix Valid Transaction Determination

### DIFF
--- a/src/routes/tx/[tx]/+page.svelte
+++ b/src/routes/tx/[tx]/+page.svelte
@@ -60,7 +60,7 @@
     $: ({ raw, ...rest } = data || { raw: null });
 </script>
 
-{#if $txn == true}
+{#if $transaction?.data?.signature}
     <div class="content mb-4 mt-4 flex justify-between px-3">
         <h1 class="text-xl font-bold">Transaction</h1>
         <div


### PR DESCRIPTION
This PR aims to fix how X-ray determines valid transactions. Currently, we check if a transaction is valid based on their logs. This means that for a valid transaction that doesn't contain any log messages, we throw an error and state the transaction is not found. A better way to check if a transaction is valid is if its transaction signature exists 