### PR TITLE
fix: use Intl.DateTimeFormat for timestamps

### DIFF
--- a/src/lib/util/format-date.ts
+++ b/src/lib/util/format-date.ts
@@ -8,13 +8,11 @@ export default (timestamp: number) => {
             ? new Date(timestamp * 1000)
             : new Date(timestamp);
 
-    const dateString = `${date.getMonth() + 1}/${date.getDate()}/${String(
-        date.getFullYear()
-    ).slice(-2)}`;
-
-    const timeString = date.toLocaleTimeString();
-
-    return `${timeString.slice(0, timeString.length - 6)} ${timeString.slice(
-        -2
-    )} ${dateString}`;
+    return Intl.DateTimeFormat(undefined, {
+        hour: "numeric",
+        minute: "numeric",
+        day: "numeric",
+        month: "numeric",
+        year: "2-digit",
+    }).format(date);
 };


### PR DESCRIPTION
Sorts out the time formatting with 24-hour locales which lack AM/PM symbol.

On 12h locale, "10:11:00 PM" was sliced to "10:11 PM" (hh:mm a)
On 24h locale, "22:11:00" was sliced to "22 00" (hh ss)

Intl.DateTimeFormat has the same coverage as Date.toLocaleString. Format is a bit different but.. 🤷‍♂️