### PR TITLE
fix: nft burn tx handling different cnft events

### DIFF
--- a/src/lib/components/transaction.svelte
+++ b/src/lib/components/transaction.svelte
@@ -3,14 +3,15 @@
 
     import { ProtonCustomActionLabelTypes } from "$lib/xray";
 
-    import { fade, fly } from "svelte/transition";
     import { transactionActionsMetadata } from "$lib/types";
+    import { fade, fly } from "svelte/transition";
 
     import formatDate from "$lib/util/format-date";
 
     export let transaction: ProtonTransaction;
 
     import Icon from "$lib/components/icon.svelte";
+    import { TransactionType } from "helius-sdk";
     import IntersectionObserver from "svelte-intersection-observer";
     import shortenString from "../util/shorten-string";
     import TokenProvider from "./providers/token-provider.svelte";
@@ -229,7 +230,7 @@
                                                                 ].label}
                                                             </p>
                                                         </h3>
-                                                    {:else if !action?.actionType?.includes("NFT")}
+                                                    {:else if !action?.actionType?.includes("NFT") || action?.actionType === TransactionType.COMPRESSED_NFT_MINT}
                                                         <div class="flex">
                                                             {#if action?.actionType?.includes("SENT") && action.to}
                                                                 <p
@@ -327,7 +328,7 @@
                                                     <div
                                                         class="absolute -left-3 top-1/2 h-0.5 w-3 -translate-y-1/2 rounded-full bg-secondary"
                                                     />
-                                                    {#if action?.actionType?.includes("RECEIVED") || action?.actionType?.includes("NFT_SELL") || action?.actionType?.includes("AIRDROP")}
+                                                    {#if action?.actionType?.includes("RECEIVED") || action?.actionType?.includes("NFT_SELL") || action?.actionType?.includes("AIRDROP") || action?.actionType === TransactionType.COMPRESSED_NFT_MINT}
                                                         <h3
                                                             class="text-bold text-success"
                                                         >

--- a/src/lib/xray/lib/parser/parsers/nft.ts
+++ b/src/lib/xray/lib/parser/parsers/nft.ts
@@ -520,11 +520,6 @@ export const parseCompressedNftBurn: ProtonParser = (transaction, address) => {
     const nftEvent = returnCompressedNftEventArray(
         transaction.events.compressed
     );
-    // const nftEvent = Array.isArray(transaction.events.compressed)
-    //     ? transaction.events.compressed
-    //     : transaction.events.compressed
-    //     ? [transaction.events.compressed]
-    //     : [];
     const { signature, timestamp, accountData, type, source } = transaction;
 
     const fee = transaction.fee / LAMPORTS_PER_SOL;


### PR DESCRIPTION
Original issue: https://x.com/sol_idity/status/1762391698456412337?s=20
Fix: https://x.com/scammo_/status/1762407502233096255?s=20

Problem: When iterating through the transaction.events.compressed array, it was assumed that all compressed events in a BURN_COMPRESSED_NFT tx type would also be a burn, but this tx also included a MINT_COMPRESSED_NFT. 