### PR TITLE
Add nifty asset pages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
             "dependencies": {
                 "@coral-xyz/anchor": "^0.29.0",
                 "@lottiefiles/svelte-lottie-player": "^0.3.0",
-                "@nifty-oss/asset": "0.2.0",
+                "@nifty-oss/asset": "^0.3.0",
                 "@onsol/tldparser": "^0.5.3",
                 "@solana/spl-account-compression": "^0.1.8",
                 "@solana/spl-token-registry": "^0.2.4574",
@@ -1834,9 +1834,9 @@
             }
         },
         "node_modules/@nifty-oss/asset": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/@nifty-oss/asset/-/asset-0.2.0.tgz",
-            "integrity": "sha512-TSr5hSZNVSLKweDCOUdyPHpjKiZQwUpxIjOxWADTt85S2bzZl3CZPXvT3kpVJ0QjjtUkDUBZwN52rRiL78x25Q==",
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/@nifty-oss/asset/-/asset-0.3.0.tgz",
+            "integrity": "sha512-2pAzMLYxCF2s/2NdKSxL/KwMhw/X6U2l2fHYpVkJbeym9h7kKe53mStiwXvX/hmFKGuWpfCySk8Qz6JUtUEUhA==",
             "peerDependencies": {
                 "@metaplex-foundation/umi": "^0.9.1"
             }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
             "dependencies": {
                 "@coral-xyz/anchor": "^0.29.0",
                 "@lottiefiles/svelte-lottie-player": "^0.3.0",
+                "@nifty-oss/asset": "0.2.0",
                 "@onsol/tldparser": "^0.5.3",
                 "@solana/spl-account-compression": "^0.1.8",
                 "@solana/spl-token-registry": "^0.2.4574",
@@ -1755,6 +1756,69 @@
                 "debug": "^4.3.4"
             }
         },
+        "node_modules/@metaplex-foundation/umi": {
+            "version": "0.9.1",
+            "resolved": "https://registry.npmjs.org/@metaplex-foundation/umi/-/umi-0.9.1.tgz",
+            "integrity": "sha512-IhHoOvp4vfO/++YL+78+iVuLM53+FDwUOZDYgH6lx0jYXyQ27BeaieeR5i+q3A9dz4KxQo5Nzc5aCA1109QGCQ==",
+            "peer": true,
+            "dependencies": {
+                "@metaplex-foundation/umi-options": "^0.8.9",
+                "@metaplex-foundation/umi-public-keys": "^0.8.9",
+                "@metaplex-foundation/umi-serializers": "^0.9.0"
+            }
+        },
+        "node_modules/@metaplex-foundation/umi-options": {
+            "version": "0.8.9",
+            "resolved": "https://registry.npmjs.org/@metaplex-foundation/umi-options/-/umi-options-0.8.9.tgz",
+            "integrity": "sha512-jSQ61sZMPSAk/TXn8v8fPqtz3x8d0/blVZXLLbpVbo2/T5XobiI6/MfmlUosAjAUaQl6bHRF8aIIqZEFkJiy4A==",
+            "peer": true
+        },
+        "node_modules/@metaplex-foundation/umi-public-keys": {
+            "version": "0.8.9",
+            "resolved": "https://registry.npmjs.org/@metaplex-foundation/umi-public-keys/-/umi-public-keys-0.8.9.tgz",
+            "integrity": "sha512-CxMzN7dgVGOq9OcNCJe2casKUpJ3RmTVoOvDFyeoTQuK+vkZ1YSSahbqC1iGuHEtKTLSjtWjKvUU6O7zWFTw3Q==",
+            "peer": true,
+            "dependencies": {
+                "@metaplex-foundation/umi-serializers-encodings": "^0.8.9"
+            }
+        },
+        "node_modules/@metaplex-foundation/umi-serializers": {
+            "version": "0.9.0",
+            "resolved": "https://registry.npmjs.org/@metaplex-foundation/umi-serializers/-/umi-serializers-0.9.0.tgz",
+            "integrity": "sha512-hAOW9Djl4w4ioKeR4erDZl5IG4iJdP0xA19ZomdaCbMhYAAmG/FEs5khh0uT2mq53/MnzWcXSUPoO8WBN4Q+Vg==",
+            "peer": true,
+            "dependencies": {
+                "@metaplex-foundation/umi-options": "^0.8.9",
+                "@metaplex-foundation/umi-public-keys": "^0.8.9",
+                "@metaplex-foundation/umi-serializers-core": "^0.8.9",
+                "@metaplex-foundation/umi-serializers-encodings": "^0.8.9",
+                "@metaplex-foundation/umi-serializers-numbers": "^0.8.9"
+            }
+        },
+        "node_modules/@metaplex-foundation/umi-serializers-core": {
+            "version": "0.8.9",
+            "resolved": "https://registry.npmjs.org/@metaplex-foundation/umi-serializers-core/-/umi-serializers-core-0.8.9.tgz",
+            "integrity": "sha512-WT82tkiYJ0Qmscp7uTj1Hz6aWQPETwaKLAENAUN5DeWghkuBKtuxyBKVvEOuoXerJSdhiAk0e8DWA4cxcTTQ/w==",
+            "peer": true
+        },
+        "node_modules/@metaplex-foundation/umi-serializers-encodings": {
+            "version": "0.8.9",
+            "resolved": "https://registry.npmjs.org/@metaplex-foundation/umi-serializers-encodings/-/umi-serializers-encodings-0.8.9.tgz",
+            "integrity": "sha512-N3VWLDTJ0bzzMKcJDL08U3FaqRmwlN79FyE4BHj6bbAaJ9LEHjDQ9RJijZyWqTm0jE7I750fU7Ow5EZL38Xi6Q==",
+            "peer": true,
+            "dependencies": {
+                "@metaplex-foundation/umi-serializers-core": "^0.8.9"
+            }
+        },
+        "node_modules/@metaplex-foundation/umi-serializers-numbers": {
+            "version": "0.8.9",
+            "resolved": "https://registry.npmjs.org/@metaplex-foundation/umi-serializers-numbers/-/umi-serializers-numbers-0.8.9.tgz",
+            "integrity": "sha512-NtBf1fnVNQJHFQjLFzRu2i9GGnigb9hOm/Gfrk628d0q0tRJB7BOM3bs5C61VAs7kJs4yd+pDNVAERJkknQ7Lg==",
+            "peer": true,
+            "dependencies": {
+                "@metaplex-foundation/umi-serializers-core": "^0.8.9"
+            }
+        },
         "node_modules/@ngraveio/bc-ur": {
             "version": "1.1.6",
             "resolved": "https://registry.npmjs.org/@ngraveio/bc-ur/-/bc-ur-1.1.6.tgz",
@@ -1767,6 +1831,14 @@
                 "crc": "^3.8.0",
                 "jsbi": "^3.1.5",
                 "sha.js": "^2.4.11"
+            }
+        },
+        "node_modules/@nifty-oss/asset": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/@nifty-oss/asset/-/asset-0.2.0.tgz",
+            "integrity": "sha512-TSr5hSZNVSLKweDCOUdyPHpjKiZQwUpxIjOxWADTt85S2bzZl3CZPXvT3kpVJ0QjjtUkDUBZwN52rRiL78x25Q==",
+            "peerDependencies": {
+                "@metaplex-foundation/umi": "^0.9.1"
             }
         },
         "node_modules/@noble/curves": {

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "dependencies": {
         "@coral-xyz/anchor": "^0.29.0",
         "@lottiefiles/svelte-lottie-player": "^0.3.0",
+        "@nifty-oss/asset": "0.2.0",
         "@onsol/tldparser": "^0.5.3",
         "@solana/spl-account-compression": "^0.1.8",
         "@solana/spl-token-registry": "^0.2.4574",

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "dependencies": {
         "@coral-xyz/anchor": "^0.29.0",
         "@lottiefiles/svelte-lottie-player": "^0.3.0",
-        "@nifty-oss/asset": "0.2.0",
+        "@nifty-oss/asset": "^0.3.0",
         "@onsol/tldparser": "^0.5.3",
         "@solana/spl-account-compression": "^0.1.8",
         "@solana/spl-token-registry": "^0.2.4574",

--- a/src/lib/components/providers/nifty-asset-provider.svelte
+++ b/src/lib/components/providers/nifty-asset-provider.svelte
@@ -1,0 +1,98 @@
+<script lang="ts">
+    import type { UINiftyAsset, UITokenMetadata } from "$lib/types";
+    import { SOL } from "$lib/xray";
+    import { page } from "$app/stores";
+    import { trpcWithQuery } from "$lib/trpc/client";
+    import IntersectionObserver from "svelte-intersection-observer";
+    import { ExtensionType, getExtension } from "@nifty-oss/asset";
+
+    export let address: string | undefined = undefined;
+
+    export let asset: UINiftyAsset | undefined = undefined;
+
+    export let status: { isLoading: boolean; isError: boolean } = {
+        isError: false,
+        isLoading: true,
+    };
+
+    let intersecting = false;
+    const params = new URLSearchParams(window.location.search);
+    const network = params.get("network");
+    const isMainnetValue = network !== "devnet";
+    const client = trpcWithQuery($page);
+
+    let account: any | undefined;
+
+    if (address) {
+        account = client.niftyAsset.createQuery([address, isMainnetValue], {
+            refetchOnMount: false,
+            refetchOnWindowFocus: false,
+        });
+    }
+
+    $: if ($account && $account.data) {
+        status = { isError: $account.isError, isLoading: $account.isLoading };
+        updateAsset($account.data[0]);
+    }
+
+    const updateAsset = (data: UINiftyAsset) => {
+        asset = data;
+
+        if (asset) {
+            const metadata = getExtension(asset, ExtensionType.Metadata);
+
+            if (metadata && metadata.uri) {
+                (async () => {
+                    try {
+                        asset.json = await fetchJsonMetadata(metadata.uri);
+                    } catch (error) {
+                        // eslint-disable-next-line no-console
+                        console.error("Error in fetchJsonMetadata:", error);
+                    }
+                })();
+            }
+        }
+    };
+
+    const fetchJsonMetadata = async (jsonUri: string) => {
+        try {
+            const response = await fetch(jsonUri);
+            if (!response.ok) {
+                throw new Error(`Status ${response.status}`);
+            }
+            const contentType = response.headers.get("content-type");
+            if (!contentType || !contentType.includes("application/json")) {
+                throw new TypeError("Received non-JSON content type");
+            }
+            return await response.json();
+        } catch (error) {
+            // eslint-disable-next-line no-console
+            console.error("Error fetching or parsing JSON metadata:", error);
+            return "";
+        }
+    };
+
+    let element: HTMLDivElement;
+
+    $: loading = address !== SOL && status.isLoading;
+
+    $: failed = status.isError;
+</script>
+
+<div>
+    <IntersectionObserver
+        once={true}
+        {element}
+        bind:intersecting
+    >
+        <div bind:this={element} />
+
+        {#if intersecting}
+            <slot
+                {asset}
+                {loading}
+                {failed}
+            />
+        {/if}
+    </IntersectionObserver>
+</div>

--- a/src/lib/trpc/router.ts
+++ b/src/lib/trpc/router.ts
@@ -9,6 +9,7 @@ import { balances } from "$lib/trpc/routes/balances";
 import { concurrentMerkleTree } from "$lib/trpc/routes/concurrent-merkle-tree";
 import { currentSlot } from "$lib/trpc/routes/current-slot";
 import { deprecatedImage } from "./routes/deprecated-image";
+import { niftyAsset } from "$lib/trpc/routes/nifty-asset";
 import { price } from "$lib/trpc/routes/price";
 import { rawTransaction } from "$lib/trpc/routes/raw-transaction";
 import { searchAssets } from "./routes/search-assets";
@@ -33,6 +34,7 @@ export const router = t.router({
     concurrentMerkleTree,
     currentSlot,
     deprecatedImage,
+    niftyAsset,
     price,
     rawTransaction,
     searchAssets,

--- a/src/lib/trpc/routes/nifty-asset.ts
+++ b/src/lib/trpc/routes/nifty-asset.ts
@@ -1,0 +1,32 @@
+import { z } from "zod";
+
+import { t } from "$lib/trpc/t";
+
+import { connect } from "$lib/xray";
+import { LAMPORTS_PER_SOL, PublicKey, Connection } from "@solana/web3.js";
+import { getRPCUrl } from "$lib/util/get-rpc-url";
+
+import { HELIUS_API_KEY } from "$env/static/private";
+import { getAssetAccountDataSerializer } from "@nifty-oss/asset";
+
+export const niftyAsset = t.procedure
+    .input(z.tuple([z.string(), z.boolean()]))
+    .query(async ({ input }) => {
+        const [address, isMainnet] = input;
+        const connection = new Connection(
+            getRPCUrl(`?api-key=${HELIUS_API_KEY}`, isMainnet),
+            "confirmed"
+        );
+
+        const pubKey = new PublicKey(address);
+
+        const accountInfo = await connection.getAccountInfo(pubKey);
+
+        if (accountInfo) {
+            return getAssetAccountDataSerializer().deserialize(
+                accountInfo.data
+            );
+        }
+
+        return null;
+    });

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -5,7 +5,10 @@ import type { EnrichedTransaction } from "helius-sdk";
 import type { ProtonTransaction, ProtonTransactionAction } from "$lib/xray";
 
 import type { IconPaths, modals } from "$lib/config";
+
 import type { SOL } from "$lib/xray";
+
+import type { Asset } from "@nifty-oss/asset";
 
 export * from "$lib/config";
 
@@ -143,3 +146,6 @@ export type UISolAccountToken = {
     balanceInUSD: number;
     price: number;
 };
+
+/** Used in the Nifty Asset pages. */
+export type UINiftyAsset = Asset & { json: any };

--- a/src/lib/util/stores/nifty-asset.ts
+++ b/src/lib/util/stores/nifty-asset.ts
@@ -1,0 +1,4 @@
+import type { UINiftyAsset } from "$lib/types";
+import { writable } from "svelte/store";
+
+export const niftyAssetStore = writable<UINiftyAsset | null>(null);

--- a/src/lib/xray/lib/search.ts
+++ b/src/lib/xray/lib/search.ts
@@ -62,18 +62,19 @@ export const search = async (
         const pubkey = new PublicKey(query);
         const account = await connection.getAccountInfo(pubkey);
         const program = account?.owner.toString();
-
-        const probablyToken =
-            program === "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA" ||
-            program === "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb" ||
-            account === null;
-
         let addressType!: "token" | "account" | "nifty-asset";
-        if (probablyToken) {
-            addressType = "token";
-        } else if (program && program === ASSET_PROGRAM_ID) {
-            addressType = "nifty-asset";
+
+        if (account) {
+            if (
+                program === "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA" ||
+                program === "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"
+            ) {
+                addressType = "token";
+            } else if (program === ASSET_PROGRAM_ID) {
+                addressType = "nifty-asset";
+            }
         }
+
         addressType ??= "account";
 
         return {

--- a/src/lib/xray/lib/search.ts
+++ b/src/lib/xray/lib/search.ts
@@ -8,6 +8,7 @@ import { TldParser } from "@onsol/tldparser";
 import { browser } from "$app/environment";
 
 import getJupiterTokens from "$lib/util/get-tokens";
+import { ASSET_PROGRAM_ID } from "@nifty-oss/asset";
 
 export interface SearchResult {
     url: string;
@@ -23,6 +24,7 @@ type SearchResultType =
     | "transaction"
     | "bonfida-domain"
     | "ans-domain"
+    | "nifty-asset"
     | null;
 
 const searchDefaults: SearchResult = {
@@ -66,9 +68,11 @@ export const search = async (
             program === "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb" ||
             account === null;
 
-        let addressType!: "token" | "account";
+        let addressType!: "token" | "account" | "nifty-asset";
         if (probablyToken) {
             addressType = "token";
+        } else if (program && program === ASSET_PROGRAM_ID) {
+            addressType = "nifty-asset";
         }
         addressType ??= "account";
 

--- a/src/routes/account/[account]/assets/+page.svelte
+++ b/src/routes/account/[account]/assets/+page.svelte
@@ -42,7 +42,9 @@
 
             {#if asset.burnt !== true}
                 <a
-                    href="/token/{asset.id}?network={isMainnetValue ? 'mainnet' : 'devnet'}"
+                    href="/token/{asset.id}?network={isMainnetValue
+                        ? 'mainnet'
+                        : 'devnet'}"
                 >
                     <Image
                         src={image?.uri}
@@ -50,7 +52,7 @@
                         alt=""
                     />
                 </a>
-                {/if}
+            {/if}
         {/each}
     {/each}
 </div>

--- a/src/routes/nifty-asset/[asset]/+page.svelte
+++ b/src/routes/nifty-asset/[asset]/+page.svelte
@@ -166,19 +166,19 @@
                 class="relative flex flex-wrap items-center justify-between bg-base-100"
             >
                 <div class="flex items-center space-x-2">
-                    <div class="badge-outline badge uppercase">
+                    <div class="badge badge-outline uppercase">
                         {asset.mutable ? "mutable" : "immutable"}
                     </div>
                     {#if mediaType === "onchain"}
-                        <div class="badge-outline badge uppercase">
+                        <div class="badge badge-outline uppercase">
                             on-chain media
                         </div>
                     {/if}
                     {#if grouping}
-                        <div class="badge-outline badge uppercase">group</div>
+                        <div class="badge badge-outline uppercase">group</div>
                     {/if}
                     {#if asset.standard !== Standard.NonFungible}
-                        <div class="badge-outline badge uppercase">
+                        <div class="badge badge-outline uppercase">
                             {Standard[asset.standard]}
                         </div>
                     {/if}
@@ -318,7 +318,7 @@
                                         <h4>Delegate</h4>
                                         {#each asset.delegate.roles as role}
                                             <div
-                                                class="badge-outline badge uppercase"
+                                                class="badge badge-outline uppercase"
                                             >
                                                 {DelegateRole[role]}
                                             </div>
@@ -709,7 +709,7 @@
                                             <h4>Delegate</h4>
                                             {#each manager.delegate.roles as role}
                                                 <div
-                                                    class="badge-outline badge uppercase"
+                                                    class="badge badge-outline uppercase"
                                                 >
                                                     {DelegateRole[role]}
                                                 </div>

--- a/src/routes/nifty-asset/[asset]/+page.svelte
+++ b/src/routes/nifty-asset/[asset]/+page.svelte
@@ -635,6 +635,32 @@
                                                 {grouping.maxSize}
                                             </p>
                                         </div>
+                                        {#if grouping.delegate}
+                                            <a
+                                                class="card p-0"
+                                                href="/account/{grouping.delegate}?network={isMainnetValue
+                                                    ? 'mainnet'
+                                                    : 'devnet'}"
+                                            >
+                                                <header
+                                                    class="flex items-center justify-between gap-6 text-sm font-medium uppercase text-gray-500"
+                                                >
+                                                    <h4>Delegate</h4>
+                                                </header>
+                                                <p class="text-sm">
+                                                    {grouping.delegate}
+                                                </p>
+                                            </a>
+                                        {:else}
+                                            <div class="card p-0">
+                                                <header
+                                                    class="flex items-center justify-between gap-6 text-sm font-medium uppercase text-gray-500"
+                                                >
+                                                    <h4>Delegate</h4>
+                                                </header>
+                                                <p class="text-sm">None</p>
+                                            </div>
+                                        {/if}
                                     </div>
                                 </Collapse>
                             </div>
@@ -796,19 +822,32 @@
                                         </header>
                                         <p class="text-sm">{proxy.bump}</p>
                                     </div>
-                                    <a
-                                        class="card p-0"
-                                        href={proxy.authority}
-                                    >
-                                        <header
-                                            class="flex items-center justify-between gap-6 text-sm font-medium uppercase text-gray-500"
+                                    {#if proxy.authority}
+                                        <a
+                                            class="card p-0"
+                                            href="/account/{proxy.authority}?network={isMainnetValue
+                                                ? 'mainnet'
+                                                : 'devnet'}"
                                         >
-                                            <h4>Authority</h4>
-                                        </header>
-                                        <p class="text-sm">
-                                            {proxy.authority}
-                                        </p>
-                                    </a>
+                                            <header
+                                                class="flex items-center justify-between gap-6 text-sm font-medium uppercase text-gray-500"
+                                            >
+                                                <h4>Authority</h4>
+                                            </header>
+                                            <p class="text-sm">
+                                                {proxy.authority}
+                                            </p>
+                                        </a>
+                                    {:else}
+                                        <div class="card p-0">
+                                            <header
+                                                class="flex items-center justify-between gap-6 text-sm font-medium uppercase text-gray-500"
+                                            >
+                                                <h4>Authority</h4>
+                                            </header>
+                                            <p class="text-sm">None</p>
+                                        </div>
+                                    {/if}
                                 </Collapse>
                             </div>
                         {/if}

--- a/src/routes/nifty-asset/[asset]/+page.svelte
+++ b/src/routes/nifty-asset/[asset]/+page.svelte
@@ -1,0 +1,836 @@
+<style>
+    .nav::before {
+        content: "";
+        position: absolute;
+        bottom: 0;
+        left: 0;
+        height: 100%;
+        width: 100vw;
+        transform: translate(-50%, 0);
+        background-color: black;
+    }
+
+    .img {
+        max-height: 55vh;
+    }
+</style>
+
+<script lang="ts">
+    import { page } from "$app/stores";
+    import Collapse from "$lib/components/collapse.svelte";
+    import CopyButton from "$lib/components/copy-button.svelte";
+    import JSON from "$lib/components/json.svelte";
+    import NiftyAssetProvider from "$lib/components/providers/nifty-asset-provider.svelte";
+    import type { UINiftyAsset } from "$lib/types";
+    import getMimeType from "$lib/util/get-mime-type";
+    import basisPointsToPercentage from "$lib/util/percentage";
+    import { niftyAssetStore } from "$lib/util/stores/nifty-asset";
+    import {
+        ExtensionType,
+        Standard,
+        State,
+        getExtension,
+        type Attributes,
+        type Blob,
+        type Creators,
+        type Grouping,
+        type Links,
+        type Manager,
+        type Metadata,
+        type Proxy,
+        type Royalties,
+    } from "@nifty-oss/asset";
+    import { cubicOut } from "svelte/easing";
+    import { fade, fly } from "svelte/transition";
+    import PageLoader from "./_loader.svelte";
+
+    const address = $page.params.asset;
+    const params = new URLSearchParams(window.location.search);
+    const network = params.get("network");
+    const isMainnetValue = network !== "devnet";
+    const KNOWN_IMAGE_EXTENSIONS = [
+        "image/png",
+        "image/jpeg",
+        "image/gif",
+        "image/svg+xml",
+    ];
+
+    let asset: UINiftyAsset;
+
+    let mediaUrl: string | null = null;
+    let mediaType: "image" | "video" | "onchain" | null = null;
+    let mediaBlob: string | null = null;
+
+    // extensions
+
+    let attributes: Attributes | undefined = undefined;
+    let blob: Blob | undefined = undefined;
+    let creators: Creators | undefined = undefined;
+    let grouping: Grouping | undefined = undefined;
+    let links: Links | undefined = undefined;
+    let manager: Manager | undefined = undefined;
+    let metadata: Metadata | undefined = undefined;
+    let proxy: Proxy | undefined = undefined;
+    let royalties: Royalties | undefined = undefined;
+    let hasExtensions = false;
+
+    const setMedia = async (asset: UINiftyAsset) => {
+        attributes = getExtension(asset, ExtensionType.Attributes);
+        blob = getExtension(asset, ExtensionType.Blob);
+        creators = getExtension(asset, ExtensionType.Creators);
+        grouping = getExtension(asset, ExtensionType.Grouping);
+        links = getExtension(asset, ExtensionType.Links);
+        manager = getExtension(asset, ExtensionType.Manager);
+        metadata = getExtension(asset, ExtensionType.Metadata);
+        proxy = getExtension(asset, ExtensionType.Proxy);
+        royalties = getExtension(asset, ExtensionType.Royalties);
+
+        hasExtensions = !!(
+            attributes ||
+            blob ||
+            creators ||
+            grouping ||
+            links ||
+            manager ||
+            metadata ||
+            proxy ||
+            royalties
+        );
+
+        if (blob && KNOWN_IMAGE_EXTENSIONS.includes(blob.contentType)) {
+            mediaBlob = Buffer.from(blob.data).toString("base64");
+            mediaType = "onchain";
+        }
+
+        if (asset.json && asset.json.image) {
+            mediaUrl = asset.json.image;
+            mediaType = "image";
+
+            const mimeType = await getMimeType(asset.json.image);
+            if (mimeType && mimeType.startsWith("video/")) {
+                mediaType = "video";
+            }
+        }
+    };
+
+    niftyAssetStore.subscribe((asset) => {
+        if (asset) setMedia(asset);
+    });
+
+    $: if (asset) {
+        niftyAssetStore.set(asset);
+    }
+</script>
+
+<NiftyAssetProvider
+    {address}
+    bind:asset
+    let:loading
+>
+    {#if loading}
+        <div class="content">
+            <PageLoader />
+        </div>
+    {:else}
+        <div class="nav content sticky top-14 z-30 bg-base-100 px-3 py-2">
+            <div
+                class="relative flex flex-wrap items-center justify-between bg-base-100"
+            >
+                <div>
+                    <h3 class="m-0 text-xl font-bold md:text-3xl">
+                        {asset.name}
+                    </h3>
+                </div>
+
+                <div>
+                    <div class="flex items-center space-x-2">
+                        {#if asset.json && asset.json.image}
+                            <a
+                                href={asset.json.image}
+                                target="_blank"
+                                class="btn-sm btn border-0 bg-black"
+                            >
+                                View Media
+                            </a>
+                        {/if}
+                        <CopyButton text={$page.params.search} />
+                        <CopyButton
+                            text={$page.url.href}
+                            icon="link"
+                        />
+                    </div>
+                </div>
+            </div>
+            <div
+                class="relative flex flex-wrap items-center justify-between bg-base-100"
+            >
+                <div class="flex items-center space-x-2">
+                    <div class="badge badge-outline uppercase">
+                        {asset.mutable ? "mutable" : "immutable"}
+                    </div>
+                    {#if mediaType === "onchain"}
+                        <div class="badge badge-outline uppercase">
+                            on-chain media
+                        </div>
+                    {/if}
+                    {#if asset.standard !== Standard.NonFungible}
+                        <div class="badge badge-outline uppercase">
+                            {Standard[asset.standard]}
+                        </div>
+                    {/if}
+                </div>
+            </div>
+        </div>
+
+        <div class="content px-3">
+            {#if mediaType}
+                <div class="content px-3">
+                    <div
+                        class="flex flex-col items-center justify-center"
+                        in:fade={{ delay: 100, duration: 800 }}
+                    >
+                        {#if mediaType === "video"}
+                            <!-- Video tag -->
+                            <div class="relative">
+                                <video
+                                    class="m-auto my-3 h-auto w-full rounded-md object-contain"
+                                    controls
+                                    autoplay
+                                    loop
+                                    muted
+                                    in:fade={{ delay: 600, duration: 1000 }}
+                                    src={mediaUrl}
+                                />
+                            </div>
+                        {:else if mediaType === "image"}
+                            <!-- Image tag -->
+                            <div class="relative">
+                                <img
+                                    class="img m-auto my-3 h-auto w-full rounded-md object-contain"
+                                    alt="asset media"
+                                    src={mediaUrl}
+                                    in:fade={{ delay: 600, duration: 1000 }}
+                                />
+                            </div>
+                        {:else if mediaType === "onchain"}
+                            <!-- Image tag -->
+                            <div class="relative">
+                                <img
+                                    class="img m-auto my-3 h-auto w-full rounded-md object-contain"
+                                    src={`data:${blob?.contentType};base64,${mediaBlob}`}
+                                    alt="on-chain asset media"
+                                    in:fade={{ delay: 600, duration: 1000 }}
+                                />
+                            </div>
+                        {:else}
+                            <!--Loading-->
+                            <div>Loading...</div>
+                        {/if}
+                    </div>
+                </div>
+            {/if}
+            <!-- Details -->
+            <div class="mt-3">
+                <div
+                    class="mt-3"
+                    in:fly={{
+                        delay: 100,
+                        easing: cubicOut,
+                        y: 50,
+                    }}
+                >
+                    <Collapse
+                        sectionTitle="Details"
+                        iconId="info"
+                        showDetails={true}
+                    >
+                        <div class="grid gap-2">
+                            <a
+                                class="card p-0"
+                                href="/account/{asset.authority}?network={isMainnetValue
+                                    ? 'mainnet'
+                                    : 'devnet'}"
+                            >
+                                <header
+                                    class="flex items-center justify-between gap-6 text-sm font-medium uppercase text-gray-500"
+                                >
+                                    <h4>Authority</h4>
+                                </header>
+                                <p class="text-sm">
+                                    {asset.authority}
+                                </p>
+                            </a>
+                            <a
+                                class="card p-0"
+                                href="/account/{asset.owner}?network={isMainnetValue
+                                    ? 'mainnet'
+                                    : 'devnet'}"
+                            >
+                                <header
+                                    class="flex items-center justify-between gap-6 text-sm font-medium uppercase text-gray-500"
+                                >
+                                    <h4>Owner</h4>
+                                </header>
+                                <p class="text-sm">
+                                    {asset.owner}
+                                </p>
+                            </a>
+                            {#if asset.group}
+                                <a
+                                    class="card p-0"
+                                    href="/nifty-asset/{asset.group}?network={isMainnetValue
+                                        ? 'mainnet'
+                                        : 'devnet'}"
+                                >
+                                    <header
+                                        class="flex items-center justify-between gap-6 text-sm font-medium uppercase text-gray-500"
+                                    >
+                                        <h4>Group</h4>
+                                    </header>
+                                    <p class="text-sm">
+                                        {asset.group}
+                                    </p>
+                                </a>
+                            {:else}
+                                <div class="card p-0">
+                                    <header
+                                        class="flex items-center justify-between gap-6 text-sm font-medium uppercase text-gray-500"
+                                    >
+                                        <h4>Group</h4>
+                                    </header>
+                                    <p class="text-sm">None</p>
+                                </div>
+                            {/if}
+                            {#if asset.delegate}
+                                <a
+                                    class="card p-0"
+                                    href="/account/{asset.delegate}?network={isMainnetValue
+                                        ? 'mainnet'
+                                        : 'devnet'}"
+                                >
+                                    <header
+                                        class="flex items-center justify-between gap-6 text-sm font-medium uppercase text-gray-500"
+                                    >
+                                        <h4>Delegate</h4>
+                                    </header>
+                                    <p class="text-sm">
+                                        {asset.delegate}
+                                    </p>
+                                </a>
+                            {:else}
+                                <div class="card p-0">
+                                    <header
+                                        class="flex items-center justify-between gap-6 text-sm font-medium uppercase text-gray-500"
+                                    >
+                                        <h4>Delegate</h4>
+                                    </header>
+                                    <p class="text-sm">None</p>
+                                </div>
+                            {/if}
+                            <div class="card p-0">
+                                <h4
+                                    class="text-sm font-medium uppercase text-gray-500"
+                                >
+                                    State
+                                </h4>
+                                <p class="text-sm">
+                                    {asset.state === State.Locked
+                                        ? "Locked"
+                                        : "Unlocked"}
+                                </p>
+                            </div>
+                        </div>
+                    </Collapse>
+                </div>
+            </div>
+            <!-- Description -->
+            {#if asset.json || metadata}
+                <div class="mt-3">
+                    <div
+                        class="mt-3"
+                        in:fly={{
+                            delay: 100,
+                            easing: cubicOut,
+                            y: 50,
+                        }}
+                    >
+                        <Collapse
+                            sectionTitle="Description"
+                            iconId="person"
+                        >
+                            <p>
+                                {#if asset.json && asset.json.description && asset.json.description.length > 0}
+                                    {asset.json.description}
+                                {:else if metadata && metadata.description}
+                                    {metadata.description}
+                                {/if}
+                            </p>
+                        </Collapse>
+                    </div>
+                </div>
+            {/if}
+            <!-- Royalties -->
+            {#if royalties}
+                <div
+                    class="mt-3"
+                    in:fly={{
+                        delay: 300,
+                        easing: cubicOut,
+                        y: 50,
+                    }}
+                >
+                    <Collapse
+                        sectionTitle="Creator Royalties"
+                        sectionAditionalInfo={basisPointsToPercentage(
+                            Number(royalties.basisPoints)
+                        )}
+                        iconId="percentage"
+                    >
+                        <p>
+                            {asset.name ?? "The"} creator(s) currently expect to
+                            take {basisPointsToPercentage(
+                                Number(royalties.basisPoints)
+                            )} of every secondary sale on this piece.
+                        </p>
+                    </Collapse>
+                </div>
+                <!-- Royalties Rule Set -->
+                {#if royalties.constraint.type !== "Empty"}
+                    <div
+                        class="mt-3"
+                        in:fly={{
+                            delay: 300,
+                            easing: cubicOut,
+                            y: 50,
+                        }}
+                    >
+                        <Collapse
+                            sectionTitle="Royalties Rule Set"
+                            iconId="json"
+                            showDetails={false}
+                        >
+                            <JSON
+                                data={royalties.constraint}
+                                label="token"
+                            />
+                        </Collapse>
+                    </div>
+                {/if}
+            {/if}
+            <!-- Creators -->
+            {#if creators && creators.creators.length > 0}
+                <div
+                    class="mt-3"
+                    in:fly={{
+                        delay: 300,
+                        easing: cubicOut,
+                        y: 50,
+                    }}
+                >
+                    <Collapse
+                        sectionTitle="Creators"
+                        sectionAditionalInfo={creators.creators.length}
+                        iconId="creator"
+                    >
+                        <div class="grid gap-2">
+                            {#each creators.creators as creator, idx}
+                                <a
+                                    class="card p-0"
+                                    href="/account/{creator.address}?network={isMainnetValue
+                                        ? 'mainnet'
+                                        : 'devnet'}"
+                                >
+                                    <header
+                                        class="flex items-center justify-between gap-6 text-sm font-medium text-gray-500"
+                                    >
+                                        <h4>
+                                            CREATOR {idx + 1}
+                                        </h4>
+                                        <abbr
+                                            title={`Creator ${
+                                                idx + 1
+                                            } royalties percentage`}
+                                        >
+                                            <h4>
+                                                {creator.share}%
+                                            </h4>
+                                        </abbr>
+                                    </header>
+                                    <p class="text-sm">
+                                        {creator.address}
+                                    </p>
+                                </a>
+                            {/each}
+                        </div>
+                    </Collapse>
+                </div>
+            {/if}
+            <!-- JSON Metadata -->
+            {#if asset.json}
+                <div class="mt-3">
+                    <Collapse
+                        sectionTitle="JSON Metadata"
+                        iconId="json"
+                        showDetails={false}
+                    >
+                        <JSON
+                            data={asset.json}
+                            label="token"
+                        />
+                    </Collapse>
+                </div>
+            {/if}
+            <!-- Extensions -->
+            {#if hasExtensions}
+                <div class="mt-3">
+                    <Collapse
+                        sectionTitle="Extensions"
+                        iconId="box"
+                        showDetails={false}
+                    >
+                        <p>List of extensions attached to this asset.</p>
+                        {#if attributes}
+                            <div class="mt-3">
+                                <Collapse
+                                    sectionTitle="Attributes"
+                                    iconId="attributes"
+                                >
+                                    <div class="flex flex-wrap gap-2">
+                                        {#each attributes.traits as attribute, idx}
+                                            <div class="card p-0">
+                                                <h4
+                                                    class="text-sm font-medium uppercase text-gray-500"
+                                                >
+                                                    {attribute.traitType}
+                                                </h4>
+                                                <p class="text-sm">
+                                                    {attribute.value}
+                                                </p>
+                                            </div>
+                                        {/each}
+                                    </div>
+                                </Collapse>
+                            </div>
+                        {/if}
+                        {#if blob}
+                            <div class="mt-3">
+                                <Collapse
+                                    sectionTitle="Blob"
+                                    iconId="dots"
+                                >
+                                    <div class="grid gap-2">
+                                        {#if mediaType !== "onchain" && mediaBlob}
+                                            <div class="relative">
+                                                <img
+                                                    class="img m-auto my-3 rounded-md object-contain"
+                                                    src={`data:${blob?.contentType};base64,${mediaBlob}`}
+                                                    alt="on-chain asset media"
+                                                    in:fade={{
+                                                        delay: 600,
+                                                        duration: 1000,
+                                                    }}
+                                                />
+                                            </div>
+                                        {/if}
+                                        <div class="card p-0">
+                                            <h4
+                                                class="text-sm font-medium uppercase text-gray-500"
+                                            >
+                                                Content-Type
+                                            </h4>
+                                            <p class="text-sm">
+                                                {blob.contentType}
+                                            </p>
+                                        </div>
+                                        <div class="card p-0">
+                                            <h4
+                                                class="text-sm font-medium uppercase text-gray-500"
+                                            >
+                                                Data Size
+                                            </h4>
+                                            <p class="text-sm">
+                                                {blob.data.length} bytes
+                                            </p>
+                                        </div>
+                                    </div>
+                                </Collapse>
+                            </div>
+                        {/if}
+                        {#if creators}
+                            <div class="mt-3">
+                                <Collapse
+                                    sectionTitle="Creators"
+                                    sectionAditionalInfo={creators.creators
+                                        .length}
+                                    iconId="creator"
+                                >
+                                    <div class="grid gap-2">
+                                        {#each creators.creators as creator, idx}
+                                            <a
+                                                class="card p-0"
+                                                href="/account/{creator.address}?network={isMainnetValue
+                                                    ? 'mainnet'
+                                                    : 'devnet'}"
+                                            >
+                                                <header
+                                                    class="flex items-center justify-between gap-6 text-sm font-medium text-gray-500"
+                                                >
+                                                    <h4>
+                                                        CREATOR {idx + 1}
+                                                    </h4>
+                                                    <abbr
+                                                        title={`Creator ${
+                                                            idx + 1
+                                                        } royalties percentage`}
+                                                    >
+                                                        <h4>
+                                                            {creator.share}%
+                                                        </h4>
+                                                    </abbr>
+                                                </header>
+                                                <p class="text-sm">
+                                                    {creator.address}
+                                                </p>
+                                            </a>
+                                        {/each}
+                                    </div>
+                                </Collapse>
+                            </div>
+                        {/if}
+                        {#if grouping}
+                            <div class="mt-3">
+                                <Collapse
+                                    sectionTitle="Grouping"
+                                    iconId="collection"
+                                >
+                                    <div class="grid gap-2">
+                                        <div class="card p-0">
+                                            <h4
+                                                class="text-sm font-medium uppercase text-gray-500"
+                                            >
+                                                Size
+                                            </h4>
+                                            <p class="text-sm">
+                                                {grouping.size}
+                                            </p>
+                                        </div>
+                                        <div class="card p-0">
+                                            <h4
+                                                class="text-sm font-medium uppercase text-gray-500"
+                                            >
+                                                Maximum Size
+                                            </h4>
+                                            <p class="text-sm">
+                                                {grouping.maxSize}
+                                            </p>
+                                        </div>
+                                    </div>
+                                </Collapse>
+                            </div>
+                        {/if}
+                        {#if links}
+                            <div class="mt-3">
+                                <Collapse
+                                    sectionTitle="Links"
+                                    iconId="link"
+                                >
+                                    <div class="grid gap-2">
+                                        {#each links.values as link}
+                                            <a
+                                                class="card p-0"
+                                                href={link.uri}
+                                            >
+                                                <header
+                                                    class="flex items-center justify-between gap-6 text-sm font-medium uppercase text-gray-500"
+                                                >
+                                                    <h4>{link.name}</h4>
+                                                </header>
+                                                <p class="text-sm">
+                                                    {link.uri}
+                                                </p>
+                                            </a>
+                                        {/each}
+                                    </div>
+                                </Collapse>
+                            </div>
+                        {/if}
+                        {#if manager}
+                            <div class="mt-3">
+                                <Collapse
+                                    sectionTitle="Manager"
+                                    iconId="person"
+                                >
+                                    <a
+                                        class="card p-0"
+                                        href="/account/{manager.delegate}?network={isMainnetValue
+                                            ? 'mainnet'
+                                            : 'devnet'}"
+                                    >
+                                        <header
+                                            class="flex items-center justify-between gap-6 text-sm font-medium uppercase text-gray-500"
+                                        >
+                                            <h4>Delegate</h4>
+                                        </header>
+                                        <p class="text-sm">
+                                            {manager.delegate}
+                                        </p>
+                                    </a>
+                                </Collapse>
+                            </div>
+                        {/if}
+                        {#if metadata}
+                            <div class="mt-3">
+                                <Collapse
+                                    sectionTitle="Metadata"
+                                    iconId="list"
+                                >
+                                    <div class="grid gap-2">
+                                        <div class="card p-0">
+                                            <h4
+                                                class="text-sm font-medium uppercase text-gray-500"
+                                            >
+                                                Symbol
+                                            </h4>
+                                            <p class="text-sm">
+                                                {metadata.symbol.length > 0
+                                                    ? metadata.symbol
+                                                    : "None"}
+                                            </p>
+                                        </div>
+                                        <div class="card p-0">
+                                            <h4
+                                                class="text-sm font-medium uppercase text-gray-500"
+                                            >
+                                                Description
+                                            </h4>
+                                            <p class="text-sm">
+                                                {metadata.description.length > 0
+                                                    ? metadata.description
+                                                    : "None"}
+                                            </p>
+                                        </div>
+                                        {#if metadata.uri.length > 0}
+                                            <a
+                                                class="card p-0"
+                                                href={metadata.uri}
+                                            >
+                                                <header
+                                                    class="flex items-center justify-between gap-6 text-sm font-medium uppercase text-gray-500"
+                                                >
+                                                    <h4>URI</h4>
+                                                </header>
+                                                <p class="text-sm">
+                                                    {metadata.uri}
+                                                </p>
+                                            </a>
+                                        {:else}
+                                            <div class="card p-0">
+                                                <h4
+                                                    class="text-sm font-medium uppercase text-gray-500"
+                                                >
+                                                    URI
+                                                </h4>
+                                                <p class="text-sm">None</p>
+                                            </div>
+                                        {/if}
+                                    </div>
+                                </Collapse>
+                            </div>
+                        {/if}
+                        {#if proxy}
+                            <div class="mt-3">
+                                <Collapse
+                                    sectionTitle="Proxy"
+                                    iconId="network"
+                                >
+                                    <a
+                                        class="card p-0"
+                                        href="/account/{proxy.program}?network={isMainnetValue
+                                            ? 'mainnet'
+                                            : 'devnet'}"
+                                    >
+                                        <header
+                                            class="flex items-center justify-between gap-6 text-sm font-medium uppercase text-gray-500"
+                                        >
+                                            <h4>Program</h4>
+                                        </header>
+                                        <p class="text-sm">
+                                            {proxy.program}
+                                        </p>
+                                    </a>
+                                    <div class="card p-0">
+                                        <header
+                                            class="flex items-center justify-between gap-6 text-sm font-medium text-gray-500"
+                                        >
+                                            <h4>Seeds</h4>
+                                            <CopyButton
+                                                text={proxy.seeds.toString()}
+                                                icon="link"
+                                            />
+                                        </header>
+                                        <p class="text-sm">{proxy.seeds}</p>
+                                    </div>
+                                    <div class="card p-0">
+                                        <header
+                                            class="flex items-center justify-between gap-6 text-sm font-medium uppercase text-gray-500"
+                                        >
+                                            <h4>Bump</h4>
+                                        </header>
+                                        <p class="text-sm">{proxy.bump}</p>
+                                    </div>
+                                    <a
+                                        class="card p-0"
+                                        href={proxy.authority}
+                                    >
+                                        <header
+                                            class="flex items-center justify-between gap-6 text-sm font-medium uppercase text-gray-500"
+                                        >
+                                            <h4>Authority</h4>
+                                        </header>
+                                        <p class="text-sm">
+                                            {proxy.authority}
+                                        </p>
+                                    </a>
+                                </Collapse>
+                            </div>
+                        {/if}
+                        {#if royalties}
+                            <div class="mt-3">
+                                <Collapse
+                                    sectionTitle="Royalties"
+                                    iconId="percentage"
+                                >
+                                    <div class="card p-0">
+                                        <header
+                                            class="flex items-center justify-between gap-6 text-sm font-medium uppercase text-gray-500"
+                                        >
+                                            <h4>Seller Fee</h4>
+                                        </header>
+                                        <p class="text-sm">
+                                            {royalties.basisPoints}
+                                        </p>
+                                    </div>
+                                    {#if royalties.constraint.type !== "Empty"}
+                                        <JSON
+                                            data={royalties.constraint}
+                                            label="token"
+                                        />
+                                    {:else}
+                                        <div class="card p-0">
+                                            <header
+                                                class="flex items-center justify-between gap-6 text-sm font-medium uppercase text-gray-500"
+                                            >
+                                                <h4>Constraint</h4>
+                                            </header>
+                                            <p class="text-sm">Empty</p>
+                                        </div>
+                                    {/if}
+                                </Collapse>
+                            </div>
+                        {/if}
+                    </Collapse>
+                </div>
+            {/if}
+        </div>
+    {/if}
+</NiftyAssetProvider>

--- a/src/routes/nifty-asset/[asset]/+page.svelte
+++ b/src/routes/nifty-asset/[asset]/+page.svelte
@@ -39,6 +39,7 @@
         type Metadata,
         type Proxy,
         type Royalties,
+        DelegateRole,
     } from "@nifty-oss/asset";
     import { cubicOut } from "svelte/easing";
     import { fade, fly } from "svelte/transition";
@@ -165,16 +166,19 @@
                 class="relative flex flex-wrap items-center justify-between bg-base-100"
             >
                 <div class="flex items-center space-x-2">
-                    <div class="badge badge-outline uppercase">
+                    <div class="badge-outline badge uppercase">
                         {asset.mutable ? "mutable" : "immutable"}
                     </div>
                     {#if mediaType === "onchain"}
-                        <div class="badge badge-outline uppercase">
+                        <div class="badge-outline badge uppercase">
                             on-chain media
                         </div>
                     {/if}
+                    {#if grouping}
+                        <div class="badge-outline badge uppercase">group</div>
+                    {/if}
                     {#if asset.standard !== Standard.NonFungible}
-                        <div class="badge badge-outline uppercase">
+                        <div class="badge-outline badge uppercase">
                             {Standard[asset.standard]}
                         </div>
                     {/if}
@@ -309,9 +313,16 @@
                                         : 'devnet'}"
                                 >
                                     <header
-                                        class="flex items-center justify-between gap-6 text-sm font-medium uppercase text-gray-500"
+                                        class="flex gap-2 text-sm font-medium uppercase text-gray-500"
                                     >
                                         <h4>Delegate</h4>
+                                        {#each asset.delegate.roles as role}
+                                            <div
+                                                class="badge-outline badge uppercase"
+                                            >
+                                                {DelegateRole[role]}
+                                            </div>
+                                        {/each}
                                     </header>
                                     <p class="text-sm">
                                         {asset.delegate}
@@ -667,9 +678,16 @@
                                             : 'devnet'}"
                                     >
                                         <header
-                                            class="flex items-center justify-between gap-6 text-sm font-medium uppercase text-gray-500"
+                                            class="flex gap-2 text-sm font-medium uppercase text-gray-500"
                                         >
                                             <h4>Delegate</h4>
+                                            {#each manager.delegate.roles as role}
+                                                <div
+                                                    class="badge-outline badge uppercase"
+                                                >
+                                                    {DelegateRole[role]}
+                                                </div>
+                                            {/each}
                                         </header>
                                         <p class="text-sm">
                                             {manager.delegate}

--- a/src/routes/nifty-asset/[asset]/_loader.svelte
+++ b/src/routes/nifty-asset/[asset]/_loader.svelte
@@ -1,0 +1,87 @@
+<div class="grid grid-cols-12 gap-3">
+    <div class="col-span-12">
+        <div class="flex h-7 w-full justify-center">
+            <div
+                class="my-2 h-3 w-20 animate-pulse rounded-full bg-secondary"
+            />
+        </div>
+    </div>
+    <div class="col-span-12">
+        <div class="flex w-full justify-center">
+            <div class="center card w-full md:w-1/2">
+                <div
+                    class="h-56 w-56 animate-pulse rounded-full bg-secondary"
+                />
+            </div>
+        </div>
+    </div>
+
+    <div class="col-span-10 mt-3">
+        <div class="flex w-full items-center justify-between">
+            <div class="w-3/4">
+                <div
+                    class="my-2 h-3 w-1/4 animate-pulse rounded-full bg-secondary"
+                />
+                <div
+                    class="mt-3 h-2 w-2/4 animate-pulse rounded-full bg-secondary"
+                />
+            </div>
+        </div>
+    </div>
+
+    <div class="col-span-10">
+        <div class="flex w-full items-center justify-between">
+            <div class="w-3/4">
+                <div
+                    class="my-2 h-3 w-1/4 animate-pulse rounded-full bg-secondary"
+                />
+                <div
+                    class="mt-3 h-2 w-2/4 animate-pulse rounded-full bg-secondary"
+                />
+            </div>
+        </div>
+    </div>
+
+    <div class="col-span-12">
+        <div class="flex w-full items-center justify-between">
+            <div class="w-3/4">
+                <div
+                    class="my-2 h-3 w-1/4 animate-pulse rounded-full bg-secondary"
+                />
+                <div class="flex flex-wrap">
+                    {#each [1, 2, 3, 4, 5] as i}
+                        <div class="card mr-2 mt-2 w-fit">
+                            <div
+                                class="h-3 w-14 animate-pulse rounded-full bg-secondary"
+                            />
+                            <div
+                                class="mt-2 h-2 w-20 animate-pulse rounded-full bg-secondary"
+                            />
+                        </div>
+                    {/each}
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="col-span-12">
+        <div class="flex w-full items-center justify-between">
+            <div class="w-3/4">
+                <div
+                    class="my-2 h-3 w-1/4 animate-pulse rounded-full bg-secondary"
+                />
+                <div class="flex flex-wrap">
+                    {#each [1, 2] as i}
+                        <div class="card mr-2 mt-2 w-fit">
+                            <div
+                                class="h-3 w-14 animate-pulse rounded-full bg-secondary"
+                            />
+                            <div
+                                class="mt-2 h-2 w-20 animate-pulse rounded-full bg-secondary"
+                            />
+                        </div>
+                    {/each}
+                </div>
+            </div>
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
This PR adds a page to show the details of `Asset` accounts from the Nifty Asset program, a lightweight open-source standard for non-fungible assets on Solana. `Asset` accounts can store a variable amount of information on-chain in the form of extensions – the page shows all the information on the account.

Details of the program can be found here: https://github.com/nifty-oss/asset

Here is the address of an asset on devnet: [`DKejcqEdGRz6D5WupdC1GT6RmG4vH8qnnweXSasgxPiM`](https://explorer.solana.com/address/DKejcqEdGRz6D5WupdC1GT6RmG4vH8qnnweXSasgxPiM?cluster=devnet)

And here one on mainnet: [`3WBnQbQwqe1NBNAgQUZXLv64b1uncBATWpthHyHgqgNP`](https://explorer.solana.com/address/3WBnQbQwqe1NBNAgQUZXLv64b1uncBATWpthHyHgqgNP)

![image](https://github.com/helius-labs/xray/assets/729235/e23d1d74-9e47-48bf-9687-69d39896720c)

