### PR TITLE
fix: use BigInt to prevent overflow when parsing large token amounts

### DIFF
--- a/src/lib/xray/lib/parser/utils/account-data.ts
+++ b/src/lib/xray/lib/parser/utils/account-data.ts
@@ -49,15 +49,24 @@ export const traverseAccountData = (
 
                     let amount;
                     if (tokenBalanceData.rawTokenAmount.decimals === 0) {
-                        amount = parseInt(
-                            tokenBalanceData.rawTokenAmount.tokenAmount
+                        amount = Number(
+                            BigInt(
+                                tokenBalanceData.rawTokenAmount.tokenAmount
+                            )
                         );
                     } else {
+                        const raw = BigInt(
+                            tokenBalanceData.rawTokenAmount.tokenAmount
+                        );
+                        const divisor = BigInt(
+                            10 ** tokenBalanceData.rawTokenAmount.decimals
+                        );
+                        const whole = raw / divisor;
+                        const remainder = raw % divisor;
                         amount =
-                            parseInt(
-                                tokenBalanceData.rawTokenAmount.tokenAmount
-                            ) /
-                            10 ** tokenBalanceData.rawTokenAmount.decimals;
+                            Number(whole) +
+                            Number(remainder) /
+                                10 ** tokenBalanceData.rawTokenAmount.decimals;
                     }
 
                     if (


### PR DESCRIPTION
## Bug

The token amount parser in `account-data.ts` uses `parseInt()` to parse raw token amounts. When token amounts exceed `Number.MAX_SAFE_INTEGER` (~9.0 × 10¹⁵), JavaScript loses precision, producing incorrect or negative values.

This causes the overflow issue reported in #280, where a minting transaction shows a negative amount instead of the correct minted value.

## Root Cause

`parseInt(tokenAmount)` returns a JavaScript `Number`, which only has 53 bits of integer precision. Token amounts in lamports or with high decimals can easily exceed this.

## Fix

Use `BigInt()` for intermediate arithmetic, converting to `Number` only after dividing to a safe range:
- For 0-decimal tokens: `Number(BigInt(tokenAmount))`
- For tokens with decimals: split into whole + remainder using BigInt division, then combine as Number

This preserves precision for large amounts while maintaining the existing `number` type interface.

Fixes #280